### PR TITLE
fix: remove dead #speed-display UI elements and add favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Deep Underworld - Ocean Horror</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='45' fill='%23001122'/><path d='M20 50 Q35 35 50 50 Q65 65 80 50' stroke='%2322aaff' fill='none' stroke-width='4'/><path d='M20 60 Q35 45 50 60 Q65 75 80 60' stroke='%230066aa' fill='none' stroke-width='3'/></svg>">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body { width: 100%; height: 100%; overflow: hidden; background: #000; }
@@ -99,11 +100,6 @@
     }
     #crosshair::before { width: 1px; height: 100%; left: 50%; }
     #crosshair::after { height: 1px; width: 100%; top: 50%; }
-
-    #speed-display {
-      position: absolute; top: 30px; right: 30px;
-      font-size: 0.9rem; color: #4488aa; text-align: right;
-    }
 
     #paused {
       position: fixed; inset: 0; z-index: 90;
@@ -265,9 +261,6 @@
   <div id="hud">
     <div id="depth-display">0m</div>
     <div id="depth-zone">SURFACE</div>
-    <div id="speed-display">
-      <div id="coords"></div>
-    </div>
     <div id="bars">
       <div class="bar-container">
         <span class="bar-label">Oxygen</span>


### PR DESCRIPTION
## Summary

Fixes two UX issues found during play-testing:

1. **Removed dead `#speed-display` UI elements** — The `#speed-display` div and its child `#coords` div were present in `index.html` but never populated by any JavaScript code, appearing as empty space in the HUD. Removed both the CSS rules and the HTML elements.

2. **Added favicon** — The browser console showed 404 errors for `/favicon.ico` on every page load. Added an inline SVG favicon using a data URI with a deep-ocean themed wave icon (no extra files needed).

## Changes

- `index.html`: Removed `#speed-display` CSS block, removed `<div id="speed-display">` and `<div id="coords">` HTML elements, added `<link rel="icon">` with inline SVG data URI in `<head>`.