### PR TITLE
fix: dispose geometry and materials when removing flora chunks

### DIFF
--- a/src/environment/Flora.js
+++ b/src/environment/Flora.js
@@ -221,6 +221,17 @@ export class Flora {
 
       for (const [key, group] of this.groups) {
         if (!needed.has(key)) {
+          // Dispose geometries, materials, and lights before removing
+          group.traverse(child => {
+            if (child.geometry) child.geometry.dispose();
+            if (child.material) {
+              if (Array.isArray(child.material)) {
+                child.material.forEach(m => m.dispose());
+              } else {
+                child.material.dispose();
+              }
+            }
+          });
           this.scene.remove(group);
           this.groups.delete(key);
           // Clean up kelp refs


### PR DESCRIPTION
## Problem

Flora chunks removed from the scene via `this.scene.remove(group)` did not dispose their geometries or materials. This caused the Three.js geometry count to grow from ~115 to 1,488+ as the player moved through depths, with no decrease when chunks were unloaded — a critical memory leak.

## Fix

Before removing a flora group from the scene, traverse all children and dispose their geometry and material (handling both single and array materials). This also cleans up any point lights added for bio-orb flora, since `scene.remove(group)` removes them from the scene graph along with the group.

## Changes

- **`src/environment/Flora.js`** — Added `group.traverse()` disposal loop in the `update()` chunk removal block, before `this.scene.remove(group)`.

## Validation

- `npm run build` passes successfully.