### PR TITLE
fix: make UX tester dispatch workers for all findings

### DIFF
--- a/.github/agents/ux-tester.agent.md
+++ b/.github/agents/ux-tester.agent.md
@@ -88,11 +88,11 @@ For each issue found, record:
 - **Description**: what's wrong
 - **Evidence**: screenshot or console output
 - **Likely file**: which source file to fix (use `semantic_search` if unsure)
-- **Suggested fix**: brief technical recommendation
+- **Suggested fix**: brief technical recommendation. Every issue MUST have a suggested fix — even complex ones. If an issue requires significant refactoring (e.g., converting to InstancedMesh, adding code-splitting), break it into smaller actionable sub-tasks that a single worker can handle and provide the first step as the suggested fix.
 
 ### Phase 4 — Delegate Fixes
 
-For **every fixable issue** (critical, major, AND minor), dispatch a Local Worker subagent. Don't skip issues — fix everything you find.
+For **every issue** (critical, major, AND minor), dispatch a Local Worker subagent. Do NOT skip or defer issues because they seem complex. If an issue requires significant refactoring (e.g., converting to InstancedMesh, adding code-splitting), break it into the smallest meaningful first step that a worker can implement — even a partial improvement counts. Every issue in the Phase 3 list MUST get a worker dispatched.
 
 #### Step 1 — Create ALL worktrees upfront
 
@@ -284,6 +284,8 @@ Return a structured report to the orchestrator:
 - If the dev server fails to start, report the error and stop
 - Don't stop after dispatching workers — continue through review, merge, and verification
 - Fix ALL issues, not just major ones — minor polish matters for UX quality
+- Never classify issues as "remaining known issues" or "lower priority" — every issue gets a worker
+- For complex issues, break them into incremental improvements rather than skipping them
 - Always poll for external GitHub Copilot reviews before and after each review round — don't ignore external feedback
 - Use `mcp_io_github_chr_evaluate_script` to access game internals rather than guessing
 - Each dispatched worker gets a unique slug: `ux-fix-<N>`

--- a/.github/skills/ux-testing/SKILL.md
+++ b/.github/skills/ux-testing/SKILL.md
@@ -149,6 +149,8 @@ mcp_io_github_chr_lighthouse_audit
 - Growing memory usage over time (dispose missing)
 - Long frame times during scene transitions
 
+> **Note**: For performance issues that need architectural changes (e.g., InstancedMesh, code-splitting), dispatch a worker to implement the most impactful incremental improvement — don't skip them just because the full solution is large.
+
 ### Accessibility Issues
 
 - No keyboard controls for menus
@@ -182,7 +184,7 @@ Subagent calls are blocking, so dispatch workers one at a time. Include in each 
 4. Affected file path
 5. Suggested fix
 
-Fix ALL issues — not just major ones. Minor polish matters for UX quality.
+Fix ALL issues — critical, major, AND minor. Never defer issues as "known issues" or "lower priority". If an issue requires significant refactoring, break it into the smallest meaningful first step a single worker can implement. Every issue found MUST result in a dispatched worker.
 
 ## Reviewing PRs
 


### PR DESCRIPTION
## Problem

The UX Tester agent finds issues but only dispatches workers for critical/high severity ones. Medium and low severity issues get logged as "Remaining Known Issues" but never get fixed.

## Changes

### `.github/agents/ux-tester.agent.md`

- **Phase 3**: Added explicit instruction that ALL issues must include a "Suggested fix" — complex ones should be broken into smaller actionable sub-tasks a single worker can handle.
- **Phase 4**: Changed "every fixable issue" → "every issue" and added explicit instruction to never skip/defer issues, instead breaking complex ones into the smallest meaningful first step.
- **Rules**: Added two new rules: never classify issues as "remaining known issues" and break complex issues into incremental improvements.

### `.github/skills/ux-testing/SKILL.md`

- **Dispatching Workers**: Strengthened "Fix ALL issues" instruction to explicitly prohibit deferring issues as "known issues" or "lower priority".
- **Performance Issues**: Added a note to dispatch workers for architectural changes by implementing the most impactful incremental improvement.