### PR TITLE
fix: prevent C key crash by adding Jellyfish.getPosition and error-safe animation loop

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -145,6 +145,7 @@ export class Game {
   }
 
   restart() {
+    this.hud.closeLocator();
     this.oxygen = 100;
     this.battery = 100;
     this.gameOver = false;
@@ -206,6 +207,7 @@ export class Game {
     const dt = Math.min(this.clock.getDelta(), 0.05);
     if (!this.running || this.gameOver || (!this.player.locked && !this.autoplay)) return;
 
+    try {
     // FPS counter
     this._fpsFrames++;
     this._fpsTime += dt;
@@ -267,6 +269,9 @@ export class Game {
 
     // Render with post-processing
     this.underwaterEffect.render(depth);
+    } catch (err) {
+      console.error('[deep-underworld] Animation frame error:', err);
+    }
   }
 
   _initEnvironmentColors() {

--- a/src/creatures/Jellyfish.js
+++ b/src/creatures/Jellyfish.js
@@ -301,6 +301,10 @@ export class Jellyfish {
     }
   }
 
+  getPosition() {
+    return this.group.position;
+  }
+
   getPositions() {
     return this.jellies.map(j => j.group.position);
   }


### PR DESCRIPTION
## Summary

Fixes a bug where pressing C (creature locator) during gameplay crashes the game and takes the player back to the start screen.

## Changes

### Bug 1: Jellyfish missing `getPosition()` method
- Added `getPosition()` to the `Jellyfish` class returning `this.group.position`
- All other creatures implement this method; jellyfish was the only one missing it
- This caused `CreatureManager` to skip jellyfish in distance calculations and despawn checks, and the creature locator to fail when processing jellyfish entries

### Bug 2: Animation loop has no error handling
- Wrapped the game logic inside `_animate()` in a try-catch
- `requestAnimationFrame` call stays outside the try-catch so the loop keeps running even if a single frame errors
- Caught errors are logged to console — prevents a transient error from permanently killing the game

### Bug 3: Creature locator not closed on restart
- Added `this.hud.closeLocator()` at the beginning of `restart()` so a stale locator doesn't persist across restarts

## Validation

- `npm run build` passes successfully