### PR TITLE
fix: install chrome-devtools-mcp locally and harden UX Tester Phase 0

### DIFF
--- a/.github/agents/ux-tester.agent.md
+++ b/.github/agents/ux-tester.agent.md
@@ -59,7 +59,30 @@ Verify that key tools appear in the results:
 - `mcp_io_github_chr_press_key` (keyboard input)
 - `mcp_io_github_git_pull_request_read` (PR polling)
 
-**If tools are not found**: STOP and report to the orchestrator that the Chrome DevTools MCP server is unavailable. Do NOT silently fall back to code-based analysis — browser-based testing is the core purpose of this agent.
+**If tools are not found or the liveness check fails**: You MUST output the following message verbatim and stop immediately — do nothing else:
+
+> **UX TEST ABORTED — Chrome DevTools MCP unavailable.**
+> Phase 0 tool discovery failed: `mcp_io_github_chr_new_page` was not found (or liveness check failed).
+> **Action required**: Ensure the Chrome DevTools MCP server is running. Check `.vscode/mcp.json` and restart the VS Code MCP session, then retry.
+
+After outputting that message, call `task_complete` with that message as the summary and return. Under no circumstances should you:
+- Fall back to searching source files or reading code
+- Attempt to infer issues from static analysis
+- "Take over directly" and substitute code analysis for browser testing
+- Produce a partial UX report without live browser data
+
+Browser-based testing is the **only** acceptable mode for this agent. A UX report without screenshots and live telemetry is worse than no report.
+
+#### Liveness check
+
+After confirming tools are listed, verify the browser actually works before proceeding:
+
+```
+mcp_io_github_chr_new_page
+  url: "about:blank"
+```
+
+If this call throws an error or times out, treat it as a failed liveness check and apply the same hard-stop rule above.
 
 ### Phase 1 — Launch
 

--- a/.github/skills/ux-testing/SKILL.md
+++ b/.github/skills/ux-testing/SKILL.md
@@ -17,7 +17,22 @@ tool_search_tool_regex  pattern: "mcp_io_github_chr"
 
 This loads all Chrome DevTools tools (screenshots, clicks, keyboard, console, performance, Lighthouse, etc.). Verify that `mcp_io_github_chr_new_page` appears in the results before proceeding.
 
-If the search returns no matching tools, the Chrome DevTools MCP server is not running. **STOP and report this** — do not fall back to code-based analysis.
+After completing discovery, do a quick liveness check — open `about:blank` to confirm the browser is reachable:
+
+```
+mcp_io_github_chr_new_page
+  url: "about:blank"
+```
+
+If this fails, apply the same STOP rule.
+
+If the search returns no matching tools, the Chrome DevTools MCP server is not running or not configured. **STOP immediately** — output the following and call `task_complete`:
+
+> **UX TEST ABORTED — Chrome DevTools MCP unavailable.**
+> `tool_search_tool_regex` returned no results for `mcp_io_github_chr`.
+> Check `.vscode/mcp.json` and restart the VS Code MCP session, then retry.
+
+Do NOT fall back to code-based analysis, file searching, or any substitute for live browser testing.
 
 If you also need GitHub MCP tools (for PR polling), load them too:
 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -7,7 +7,7 @@
     "io.github.ChromeDevTools/chrome-devtools-mcp": {
       "type": "stdio",
       "command": "npx",
-      "args": ["--registry", "https://registry.npmjs.org", "chrome-devtools-mcp@latest"]
+      "args": ["chrome-devtools-mcp"]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "three": "^0.170.0"
       },
       "devDependencies": {
+        "chrome-devtools-mcp": "^0.20.3",
         "vite": "^6.0.0"
       }
     },
@@ -851,6 +852,20 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chrome-devtools-mcp": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-0.20.3.tgz",
+      "integrity": "sha512-6MlNKlKa+J1FX9w4SUnFERF4MRGWLlrnZvIJGhhsuuMPM7qUG0F4SwheRyjwl0+tsTemxMCBHiib8mXkg5j6og==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "chrome-devtools": "build/src/bin/chrome-devtools.js",
+        "chrome-devtools-mcp": "build/src/bin/chrome-devtools-mcp.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "three": "^0.170.0"
   },
   "devDependencies": {
+    "chrome-devtools-mcp": "^0.20.3",
     "vite": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Root Cause

The UX Tester subagent's Chrome DevTools MCP tools were unavailable at runtime. The `mcp.json` entry was:

```json
"command": "npx",
"args": ["--registry", "https://registry.npmjs.org", "chrome-devtools-mcp@latest"]
```

This re-fetches the package from the registry on every MCP session start. In a subagent runtime context this can time out or fail silently, leaving `mcp_io_github_chr_*` tools absent and the UX Tester unable to open a browser.

## Changes

### 1. `package.json` / `package-lock.json`
- Added `chrome-devtools-mcp` (v0.20.3) as a `devDependency`
- `npx` will now resolve to the locally installed binary without a registry round-trip

### 2. `.vscode/mcp.json`
- Dropped `--registry` flag and `@latest` version pin
- New args: `["chrome-devtools-mcp"]` — simple, reliable, uses the local install

### 3. `.github/agents/ux-tester.agent.md` — Phase 0 hardening
- Replaced soft "STOP and report" with a **mandatory verbatim abort message** the agent must output
- Added explicit `task_complete` call instruction  
- Added explicit "do NOT" list forbidding code-based fallback, static analysis, and partial reports without live browser data
- Added a **liveness check** step (open `about:blank`) to verify the browser is reachable before Phase 1

### 4. `.github/skills/ux-testing/SKILL.md` — matching hardening
- Updated "If search returns no matching tools" paragraph with the same abort message pattern
- Added liveness check note after the tool discovery step