### PR TITLE
feat: remove oxygen and battery mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,8 +100,7 @@
     .bar-fill {
       height: 100%; border-radius: 3px; transition: width 0.3s;
     }
-    #oxygen-bar { background: #22aaff; box-shadow: 0 0 8px #22aaff88; }
-    #battery-bar { background: #ffaa22; box-shadow: 0 0 8px #ffaa2288; }
+
 
     #warning-text {
       position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
@@ -291,16 +290,7 @@
   <div id="hud" role="status" aria-label="HUD">
     <div id="depth-display" aria-label="Depth">0m</div>
     <div id="depth-zone" aria-label="Depth zone">SURFACE</div>
-    <div id="bars">
-      <div class="bar-container">
-        <span class="bar-label">Oxygen</span>
-        <div class="bar-track"><div class="bar-fill" id="oxygen-bar" style="width:100%"></div></div>
-      </div>
-      <div class="bar-container">
-        <span class="bar-label">Battery</span>
-        <div class="bar-track"><div class="bar-fill" id="battery-bar" style="width:100%"></div></div>
-      </div>
-    </div>
+
     <div id="warning-text"></div>
     <div id="crosshair"></div>
     <canvas id="sonar" width="150" height="150"></canvas>
@@ -353,7 +343,7 @@
 
   <div id="game-over" role="dialog" aria-label="Game over">
     <h1>LOST AT SEA</h1>
-    <p>Your oxygen supply has been depleted</p>
+    <p>You have been lost in the deep</p>
     <button class="start-btn" id="restart-btn" data-testid="restart-btn">Try Again</button>
   </div>
 

--- a/src/Game.js
+++ b/src/Game.js
@@ -7,7 +7,6 @@ import { CreatureManager } from './creatures/CreatureManager.js';
 import { HUD } from './ui/HUD.js';
 import { AudioManager } from './audio/AudioManager.js';
 import { UnderwaterEffect } from './shaders/UnderwaterEffect.js';
-import { SupplyCache } from './environment/SupplyCache.js';
 
 export class Game {
   constructor() {
@@ -43,7 +42,6 @@ export class Game {
     this.hud = new HUD();
     this.audio = new AudioManager();
     this.underwaterEffect = new UnderwaterEffect(this.renderer, this.scene, this.camera);
-    this.supplyCaches = new SupplyCache(this.scene, this.terrain);
 
     // Alias so automated tests can use game.creatureManager or game.creatures
     this.creatureManager = this.creatures;
@@ -54,8 +52,6 @@ export class Game {
     this._fpsTime = 0;
 
     // Game state
-    this.oxygen = 100;
-    this.battery = 100;
     this.flashlightOn = false;
     this.gameOver = false;
     this.maxDepth = 0;
@@ -151,8 +147,6 @@ export class Game {
 
   restart() {
     this.hud.closeLocator();
-    this.oxygen = 100;
-    this.battery = 100;
     this.gameOver = false;
     this.flashlightOn = false;
     this.pendingStart = false;
@@ -160,7 +154,6 @@ export class Game {
     this.gameOverOverlay.classList.add('visible');
     this.player.reset();
     this.creatures.reset();
-    this.supplyCaches.reset();
     this.player.flashlight.visible = false;
     this.pauseOverlay.classList.remove('visible');
     this._descentActive = false;
@@ -178,7 +171,6 @@ export class Game {
   }
 
   _toggleFlashlight() {
-    if (this.battery <= 0) return;
     this.flashlightOn = !this.flashlightOn;
     this.player.flashlight.visible = this.flashlightOn;
   }
@@ -245,54 +237,18 @@ export class Game {
     this.terrain.update(this.player.position);
     this.flora.update(dt, this.player.position);
     this.creatures.update(dt, this.player.position, depth);
-    this.audio.update(dt, depth, this.creatures.getNearestCreatureDistance(this.player.position), this.oxygen);
-
-    // Supply cache pickups
-    const pickups = this.supplyCaches.update(dt, this.player.position);
-    for (const pickup of pickups) {
-      this.oxygen = Math.min(100, this.oxygen + pickup.oxygen);
-      this.battery = Math.min(100, this.battery + pickup.battery);
-      this.hud.showPickup(`+${pickup.oxygen}% O\u2082  +${pickup.battery}% Battery`);
-      this.audio.playPickup();
-    }
-
-    // Oxygen depletion
-    this.oxygen -= dt * 0.8;
-    if (depth > 200) this.oxygen -= dt * 0.3;
-    if (depth > 500) this.oxygen -= dt * 0.5;
-    this.oxygen = Math.max(0, this.oxygen);
-
-    // Battery drain when flashlight is on
-    if (this.flashlightOn) {
-      this.battery -= dt * 2;
-      if (this.battery <= 0) {
-        this.battery = 0;
-        this.flashlightOn = false;
-        this.player.flashlight.visible = false;
-      }
-    }
+    this.audio.update(dt, depth, this.creatures.getNearestCreatureDistance(this.player.position));
 
     // Depth tracking
     if (depth > this.maxDepth) this.maxDepth = depth;
 
     // Update HUD
     const creaturesByType = this.creatures.getCreaturesByType(this.player.position);
-    this.hud.update(depth, this.oxygen, this.battery, this.flashlightOn);
+    this.hud.update(depth, this.flashlightOn);
     this.hud.updateLocator(creaturesByType, this.player.position, this.camera);
 
     // Update underwater fog based on depth
     this._updateEnvironmentForDepth(depth);
-
-    // Game over check
-    if (this.oxygen <= 0) {
-      this.gameOver = true;
-      this.running = false;
-      this.hud.closeLocator();
-      this.gameOverOverlay.classList.add('visible');
-      this._pauseAudio();
-      this.player.unlock();
-      console.log('[deep-underworld] Game over — oxygen depleted at depth ' + Math.floor(depth) + 'm');
-    }
 
     // Update descent transition overlay
     if (this._descentActive) {

--- a/src/audio/AudioManager.js
+++ b/src/audio/AudioManager.js
@@ -204,12 +204,12 @@ export class AudioManager {
     }
   }
 
-  update(dt, depth, nearestCreatureDist, oxygen) {
+  update(dt, depth, nearestCreatureDist) {
     if (!this.ctx) return;
 
     // Update adaptive music
     if (this.music) {
-      this.music.update(dt, depth, nearestCreatureDist, oxygen);
+      this.music.update(dt, depth, nearestCreatureDist);
     }
 
     // Adjust drone frequencies based on depth

--- a/src/audio/MusicSystem.js
+++ b/src/audio/MusicSystem.js
@@ -415,13 +415,13 @@ export class MusicSystem {
   // =========================================================================
   //  UPDATE – called every frame from Game
   // =========================================================================
-  update(dt, depth, nearestCreatureDist, oxygen) {
+  update(dt, depth, nearestCreatureDist) {
     if (!this.started || !this.ctx) return;
 
     this.time += dt;
     this.depth = depth;
     this.creatureProx = clamp01(1 - nearestCreatureDist / 60);
-    this.oxygenStress = clamp01(1 - oxygen / 35);  // stress ramps below 35%
+    this.oxygenStress = 0;
 
     const now = this.ctx.currentTime;
 

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -37,8 +37,6 @@ export class HUD {
   constructor() {
     this.depthDisplay = document.getElementById('depth-display');
     this.depthZone = document.getElementById('depth-zone');
-    this.oxygenBar = document.getElementById('oxygen-bar');
-    this.batteryBar = document.getElementById('battery-bar');
     this.warningText = document.getElementById('warning-text');
     this.sonarCanvas = document.getElementById('sonar');
     this.sonarCtx = this.sonarCanvas.getContext('2d');
@@ -76,7 +74,7 @@ export class HUD {
     });
   }
 
-  update(depth, oxygen, battery, flashlightOn) {
+  update(depth, flashlightOn) {
     // Depth counter
     this.depthDisplay.textContent = `${Math.floor(depth)}m`;
 
@@ -99,21 +97,7 @@ export class HUD {
       }
     }
 
-    // Bars
-    this.oxygenBar.style.width = `${oxygen}%`;
-    this.oxygenBar.style.background = oxygen < 25
-      ? `hsl(0, 80%, ${50 + Math.sin(Date.now() * 0.01) * 20}%)`
-      : '#22aaff';
-
-    this.batteryBar.style.width = `${battery}%`;
-    this.batteryBar.style.background = battery < 20 ? '#ff6622' : '#ffaa22';
-
-    // Low oxygen warning
-    if (oxygen < 20 && oxygen > 0) {
-      this.warningText.textContent = 'LOW OXYGEN';
-      this.warningText.classList.add('visible');
-      this.warningText.style.opacity = 0.5 + Math.sin(Date.now() * 0.005) * 0.5;
-    } else if (this.warningTimer <= 0) {
+    if (this.warningTimer <= 0) {
       this.warningText.classList.remove('visible');
       this.warningText.style.opacity = '';
     }


### PR DESCRIPTION
## Summary

Remove the oxygen and battery resource systems from the game. These mechanics were more annoying than fun.

## Changes

- **Game.js**: Removed `oxygen` and `battery` state, oxygen depletion logic, battery drain logic, oxygen-based game over condition, supply cache pickup handling, and `SupplyCache` import/construction
- **HUD.js**: Removed oxygen/battery bar DOM references and their update logic from `update()`, removed low oxygen warning
- **AudioManager.js**: Removed `oxygen` parameter from `update()` signature  
- **MusicSystem.js**: Removed `oxygen` parameter from `update()`; `oxygenStress` is now always 0 (stress/pulse layers remain but are dormant)
- **index.html**: Removed oxygen and battery bar HTML elements, their CSS styles, and updated game-over text

## Behavior after this change

- Flashlight toggles freely without battery constraint
- No resource-based game over condition — pure exploration
- Supply caches no longer appear (entire `SupplyCache` system is unused/tree-shaken)
- Audio oxygen stress layers are silent (driven by `oxygenStress = 0`)