### PR TITLE
feat: add menu-idle preload lifecycle with procedural cache guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ npm run dev       # Start dev server at http://localhost:5173
 npm run build     # Production build
 ```
 
+## Startup Preload And Cache
+
+- A menu-idle preload phase warms non-audio systems after page load and before Begin Descent.
+- Begin Descent always takes priority and never waits for preload completion.
+- Audio remains gesture-gated and is not resumed/initialized by preload work.
+- Procedural startup metadata stays tiny in localStorage; larger snapshots use IndexedDB when available.
+- Cache key invalidation uses: `gameVersion + worldSeed + qualityTier + schemaVersion`.
+- If storage APIs are unavailable/restricted or quota is exceeded, gameplay continues with memory-only warmup.
+
 ## AI Agent Workflow
 
 This repo includes custom Copilot agents that automate development tasks. You talk to the main chat agent (the orchestrator), and it dispatches specialized subagents for you.

--- a/src/Game.js
+++ b/src/Game.js
@@ -7,6 +7,7 @@ import { CreatureManager } from './creatures/CreatureManager.js';
 import { HUD } from './ui/HUD.js';
 import { AudioManager } from './audio/AudioManager.js';
 import { UnderwaterEffect } from './shaders/UnderwaterEffect.js';
+import { PreloadCoordinator } from './PreloadCoordinator.js';
 
 export class Game {
   constructor() {
@@ -65,6 +66,17 @@ export class Game {
     this.descentOverlay = document.getElementById('descent-transition');
     this.descentProgressBar = document.getElementById('descent-progress-bar');
     this._descentActive = false;
+    this._startTransition = { owner: 'game', startRequested: false, started: false };
+
+    this.preload = new PreloadCoordinator({
+      renderer: this.renderer,
+      underwaterEffect: this.underwaterEffect,
+      player: this.player,
+      terrain: this.terrain,
+      flora: this.flora,
+      creatures: this.creatures,
+    });
+    this.preload.startMenuIdleWarmup();
 
     this._initEnvironmentColors();
     this._setupEvents();
@@ -102,6 +114,7 @@ export class Game {
         }
       } else if (this.pendingStart) {
         this.pendingStart = false;
+        this._startTransition.startRequested = false;
         this._pauseAudio();
       } else if (this.running && !this.gameOver) {
         this.pauseOverlay.classList.add('visible');
@@ -118,7 +131,9 @@ export class Game {
   }
 
   start() {
-    if (this.gameOver || this.running || this.pendingStart) return;
+    if (this.gameOver || this.running || this.pendingStart || this._startTransition.startRequested) return;
+    this._startTransition.startRequested = true;
+    this.preload.cancel('user-start');
     this.pendingStart = true;
     this.pauseOverlay.classList.remove('visible');
     this.audio.start();
@@ -150,6 +165,9 @@ export class Game {
    */
   startAutoplay() {
     if (this.running) return;
+    this.preload.cancel('autoplay-start');
+    this._startTransition.startRequested = false;
+    this._startTransition.started = true;
     this.autoplay = true;
     this.player.locked = true; // simulate lock without real pointer lock
     this.menuOverlay.classList.add('hidden');
@@ -197,6 +215,8 @@ export class Game {
   }
 
   _beginGameplay() {
+    this._startTransition.startRequested = false;
+    this._startTransition.started = true;
     this.pendingStart = false;
     this.menuOverlay.classList.add('hidden');
     this.gameOverOverlay.classList.remove('visible');

--- a/src/PreloadCoordinator.js
+++ b/src/PreloadCoordinator.js
@@ -1,0 +1,445 @@
+import { noise2D } from './utils/noise.js';
+
+const SCHEMA_VERSION = 1;
+const GAME_VERSION = '0.16.0';
+const IDB_NAME = 'deep-underworld-procedural-cache';
+const IDB_STORE = 'snapshots';
+const LOCAL_META_KEY = 'duw.preload.meta';
+
+const MAX_PRELOADED_CREATURES = 12;
+const MAX_PRELOADED_TERRAIN_CHUNKS = 6;
+const MAX_PRELOADED_FLORA_CHUNKS = 5;
+const FRAME_BUDGET_MS = 6;
+const WRITE_THROTTLE_MS = 5000;
+const ENTRY_TTL_MS = 1000 * 60 * 60 * 24;
+const INDEXED_DB_SIZE_CEILING = 3 * 1024 * 1024;
+
+export class PreloadCoordinator {
+  constructor({ renderer, underwaterEffect, player, terrain, flora, creatures }) {
+    this.renderer = renderer;
+    this.underwaterEffect = underwaterEffect;
+    this.player = player;
+    this.terrain = terrain;
+    this.flora = flora;
+    this.creatures = creatures;
+
+    this.state = 'idle';
+    this._token = null;
+    this._hasIdleCallback = typeof window.requestIdleCallback === 'function';
+
+    this.worldSeed = this._resolveWorldSeed();
+    this.qualityTier = this._resolveQualityTier();
+    this.cacheKey = this._buildCacheKey();
+    this.runtimeCache = new Map();
+    this.persistenceDisabledForSession = false;
+
+    this._cache = new ProceduralStartupCache({
+      cacheKey: this.cacheKey,
+      worldSeed: this.worldSeed,
+      qualityTier: this.qualityTier,
+      onDisablePersistence: () => {
+        this.persistenceDisabledForSession = true;
+      },
+    });
+  }
+
+  startMenuIdleWarmup() {
+    if (this.state !== 'idle') return;
+    this.state = 'warming';
+    this._token = { cancelled: false };
+    void this._runWarmup(this._token);
+  }
+
+  cancel(reason = 'cancelled') {
+    if (this.state !== 'warming') return;
+    if (this._token) {
+      this._token.cancelled = true;
+      this._token.reason = reason;
+    }
+    this.state = 'cancelled';
+  }
+
+  async _runWarmup(token) {
+    try {
+      await this._cache.init();
+      const cached = await this._cache.readSnapshot();
+      if (cached) {
+        this.runtimeCache.set('startupSnapshot', cached);
+      }
+
+      await this._runBudgeted(token, () => this._warmGpuOnce(token));
+      await this._runBudgeted(token, () => this._warmCreatureQueue(token));
+      await this._runBudgeted(token, () => this._warmTerrainAndFlora(token));
+      await this._runBudgeted(token, () => this._warmNonAudioLookups(token));
+
+      if (token.cancelled) return;
+
+      const snapshot = this._createSnapshot();
+      this.runtimeCache.set('startupSnapshot', snapshot);
+      await this._cache.writeSnapshot(snapshot);
+
+      if (!token.cancelled) {
+        this.state = 'finalized';
+      }
+    } catch (err) {
+      // Startup preload and cache failures are non-fatal.
+      console.warn('[deep-underworld] Menu-idle preload degraded:', err);
+      if (!token.cancelled) {
+        this.state = 'finalized';
+      }
+    }
+  }
+
+  async _runBudgeted(token, workStep) {
+    while (!token.cancelled) {
+      const done = await this._runSlice(token, workStep);
+      if (done) return;
+    }
+  }
+
+  async _runSlice(token, workStep) {
+    if (token.cancelled) return true;
+
+    if (this._hasIdleCallback) {
+      return new Promise(resolve => {
+        window.requestIdleCallback(() => {
+          resolve(this._drainWorkSlice(token, workStep));
+        }, { timeout: 50 });
+      });
+    }
+
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve(this._drainWorkSlice(token, workStep));
+      }, 16);
+    });
+  }
+
+  _drainWorkSlice(token, workStep) {
+    const start = performance.now();
+    while (!token.cancelled && performance.now() - start < FRAME_BUDGET_MS) {
+      if (workStep()) return true;
+    }
+    return false;
+  }
+
+  _warmGpuOnce(token) {
+    if (token.cancelled) return true;
+    if (this._gpuWarmed) return true;
+
+    this.renderer.compile(this.underwaterEffect.scene, this.underwaterEffect.camera);
+    this.underwaterEffect.render(0);
+    this._gpuWarmed = true;
+    return true;
+  }
+
+  _warmCreatureQueue(token) {
+    if (token.cancelled) return true;
+
+    this.creatures.prepareInitialQueue(this.player.position);
+    const current = this.creatures.getLoadProgress().loaded;
+    if (current >= MAX_PRELOADED_CREATURES || this.creatures.getSpawnQueueLength() === 0) {
+      return true;
+    }
+
+    this.creatures.preloadDrain(1, token);
+    return false;
+  }
+
+  _warmTerrainAndFlora(token) {
+    if (token.cancelled) return true;
+
+    if (!this._terrainPrepared) {
+      this.terrain.preloadPrepareAround(this.player.position);
+      this.flora.preloadPrepareAround(this.player.position);
+      this._terrainPrepared = true;
+    }
+
+    if (this.terrain.getChunkCount() < MAX_PRELOADED_TERRAIN_CHUNKS && this.terrain.getPendingCount() > 0) {
+      this.terrain.preloadDrain(1, token);
+      return false;
+    }
+
+    if (this.flora.getChunkCount() < MAX_PRELOADED_FLORA_CHUNKS && this.flora.getPendingCount() > 0) {
+      this.flora.preloadDrain(1, token);
+      return false;
+    }
+
+    return true;
+  }
+
+  _warmNonAudioLookups(token) {
+    if (token.cancelled) return true;
+
+    if (!this._lookupPlan) {
+      this._lookupPlan = this._buildLookupPlan();
+      this._lookupCursor = 0;
+      this._lookupChecksum = 0;
+    }
+
+    if (this._lookupCursor >= this._lookupPlan.length) return true;
+
+    const p = this._lookupPlan[this._lookupCursor++];
+    this._lookupChecksum += noise2D(p.x, p.z);
+    return this._lookupCursor >= this._lookupPlan.length;
+  }
+
+  _buildLookupPlan() {
+    const plan = [];
+    for (let x = -8; x <= 8; x++) {
+      for (let z = -8; z <= 8; z++) {
+        plan.push({ x: x * 0.07, z: z * 0.07 });
+      }
+    }
+    return plan;
+  }
+
+  _createSnapshot() {
+    const progress = this.creatures.getLoadProgress();
+    return {
+      cacheKey: this.cacheKey,
+      createdAt: Date.now(),
+      worldSeed: this.worldSeed,
+      qualityTier: this.qualityTier,
+      schemaVersion: SCHEMA_VERSION,
+      creaturePreloaded: progress.loaded,
+      creatureTotal: progress.total,
+      terrainChunks: this.terrain.getChunkCount(),
+      floraChunks: this.flora.getChunkCount(),
+      lookupChecksum: Number(this._lookupChecksum?.toFixed(4) || 0),
+      lifecycleState: this.state,
+    };
+  }
+
+  _buildCacheKey() {
+    return [GAME_VERSION, this.worldSeed, this.qualityTier, `schema-${SCHEMA_VERSION}`].join(':');
+  }
+
+  _resolveWorldSeed() {
+    const fromQuery = new URLSearchParams(window.location.search).get('seed');
+    if (fromQuery) return fromQuery;
+
+    try {
+      const key = 'duw.worldSeed';
+      const existing = window.localStorage.getItem(key);
+      if (existing) return existing;
+      const generated = String(Math.floor(Math.random() * 1_000_000_000));
+      window.localStorage.setItem(key, generated);
+      return generated;
+    } catch {
+      return 'volatile-seed';
+    }
+  }
+
+  _resolveQualityTier() {
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+    if (pixelRatio < 1.25) return 'low';
+    if (pixelRatio < 1.75) return 'medium';
+    return 'high';
+  }
+}
+
+class ProceduralStartupCache {
+  constructor({ cacheKey, worldSeed, qualityTier, onDisablePersistence }) {
+    this.cacheKey = cacheKey;
+    this.worldSeed = worldSeed;
+    this.qualityTier = qualityTier;
+    this._db = null;
+    this._nextWriteAt = 0;
+    this._onDisablePersistence = onDisablePersistence;
+    this._persistenceEnabled = true;
+  }
+
+  async init() {
+    this._writeTinyMeta({
+      gameVersion: GAME_VERSION,
+      worldSeed: this.worldSeed,
+      qualityTier: this.qualityTier,
+      schemaVersion: SCHEMA_VERSION,
+      cacheKey: this.cacheKey,
+    });
+
+    if (!window.indexedDB) {
+      this._disablePersistence('missing-indexeddb');
+      return;
+    }
+
+    try {
+      this._db = await this._openDb();
+      await this._pruneStartup();
+    } catch (err) {
+      this._disablePersistence('idb-unavailable');
+      console.warn('[deep-underworld] IndexedDB disabled for this session:', err);
+    }
+  }
+
+  async readSnapshot() {
+    if (!this._db || !this._persistenceEnabled) return null;
+
+    try {
+      const item = await this._read(this.cacheKey);
+      if (!item) return null;
+      if (!item.payload || typeof item.payload !== 'object') {
+        await this._remove(this.cacheKey);
+        return null;
+      }
+      if (item.expiresAt && item.expiresAt < Date.now()) {
+        await this._remove(this.cacheKey);
+        return null;
+      }
+
+      item.lastAccessAt = Date.now();
+      await this._write(item);
+      return item.payload;
+    } catch (err) {
+      this._disablePersistence('read-failed');
+      console.warn('[deep-underworld] Cache read failed; using memory-only warmup.', err);
+      return null;
+    }
+  }
+
+  async writeSnapshot(payload) {
+    if (!this._db || !this._persistenceEnabled) return;
+    if (Date.now() < this._nextWriteAt) return;
+
+    this._nextWriteAt = Date.now() + WRITE_THROTTLE_MS;
+    const sizeBytes = this._estimateSize(payload);
+    if (sizeBytes > INDEXED_DB_SIZE_CEILING) return;
+
+    const entry = {
+      key: this.cacheKey,
+      createdAt: Date.now(),
+      lastAccessAt: Date.now(),
+      expiresAt: Date.now() + ENTRY_TTL_MS,
+      sizeBytes,
+      payload,
+    };
+
+    try {
+      await this._write(entry);
+      await this._pruneStartup();
+      this._writeTinyMeta({
+        gameVersion: GAME_VERSION,
+        worldSeed: this.worldSeed,
+        qualityTier: this.qualityTier,
+        schemaVersion: SCHEMA_VERSION,
+        cacheKey: this.cacheKey,
+        lastPersistAt: Date.now(),
+      });
+    } catch (err) {
+      if (this._isQuotaError(err)) {
+        this._disablePersistence('quota-exceeded');
+      } else {
+        this._disablePersistence('write-failed');
+      }
+      console.warn('[deep-underworld] Persistent cache disabled for this session:', err);
+    }
+  }
+
+  async _pruneStartup() {
+    if (!this._db || !this._persistenceEnabled) return;
+
+    const now = Date.now();
+    const all = await this._readAll();
+
+    for (const entry of all) {
+      if (!entry || entry.expiresAt < now || entry.sizeBytes > INDEXED_DB_SIZE_CEILING) {
+        await this._remove(entry.key);
+      }
+    }
+
+    const fresh = (await this._readAll()).sort((a, b) => a.lastAccessAt - b.lastAccessAt);
+    let total = fresh.reduce((sum, item) => sum + (item.sizeBytes || 0), 0);
+
+    for (const entry of fresh) {
+      if (total <= INDEXED_DB_SIZE_CEILING) break;
+      await this._remove(entry.key);
+      total -= entry.sizeBytes || 0;
+    }
+  }
+
+  _disablePersistence(reason) {
+    this._persistenceEnabled = false;
+    this._db = null;
+    this._writeTinyMeta({ persistenceDisabled: true, reason, cacheKey: this.cacheKey });
+    this._onDisablePersistence();
+  }
+
+  _writeTinyMeta(data) {
+    try {
+      const existingRaw = window.localStorage.getItem(LOCAL_META_KEY);
+      const existing = existingRaw ? JSON.parse(existingRaw) : {};
+      const next = { ...existing, ...data, updatedAt: Date.now() };
+      window.localStorage.setItem(LOCAL_META_KEY, JSON.stringify(next));
+    } catch {
+      // localStorage can be blocked in restrictive/private contexts.
+    }
+  }
+
+  _estimateSize(value) {
+    try {
+      return new TextEncoder().encode(JSON.stringify(value)).length;
+    } catch {
+      return 0;
+    }
+  }
+
+  _isQuotaError(err) {
+    return err && (
+      err.name === 'QuotaExceededError' ||
+      err.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+      String(err.message || '').toLowerCase().includes('quota')
+    );
+  }
+
+  _openDb() {
+    return new Promise((resolve, reject) => {
+      const req = window.indexedDB.open(IDB_NAME, 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(IDB_STORE)) {
+          db.createObjectStore(IDB_STORE, { keyPath: 'key' });
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error || new Error('IndexedDB open failed'));
+      req.onblocked = () => reject(new Error('IndexedDB open blocked'));
+    });
+  }
+
+  _read(key) {
+    return new Promise((resolve, reject) => {
+      const tx = this._db.transaction(IDB_STORE, 'readonly');
+      const req = tx.objectStore(IDB_STORE).get(key);
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => reject(req.error || new Error('IndexedDB read failed'));
+    });
+  }
+
+  _readAll() {
+    return new Promise((resolve, reject) => {
+      const tx = this._db.transaction(IDB_STORE, 'readonly');
+      const req = tx.objectStore(IDB_STORE).getAll();
+      req.onsuccess = () => resolve(req.result || []);
+      req.onerror = () => reject(req.error || new Error('IndexedDB readAll failed'));
+    });
+  }
+
+  _write(value) {
+    return new Promise((resolve, reject) => {
+      const tx = this._db.transaction(IDB_STORE, 'readwrite');
+      const req = tx.objectStore(IDB_STORE).put(value);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error || new Error('IndexedDB write failed'));
+    });
+  }
+
+  _remove(key) {
+    return new Promise((resolve, reject) => {
+      const tx = this._db.transaction(IDB_STORE, 'readwrite');
+      const req = tx.objectStore(IDB_STORE).delete(key);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error || new Error('IndexedDB delete failed'));
+    });
+  }
+}

--- a/src/creatures/CreatureManager.js
+++ b/src/creatures/CreatureManager.js
@@ -49,6 +49,29 @@ export class CreatureManager {
     this._spawnedCount = 0;
   }
 
+  prepareInitialQueue(playerPos) {
+    if (!this.initialized) {
+      this._spawnInitialCreatures(playerPos);
+    }
+  }
+
+  preloadDrain(maxCount, cancelToken) {
+    if (maxCount <= 0) return 0;
+    let drained = 0;
+    while (this._spawnQueue.length > 0 && drained < maxCount) {
+      if (cancelToken?.cancelled) break;
+      const entry = this._spawnQueue.shift();
+      this._add(entry.type, entry.createFn(), entry.depthMin, entry.depthMax);
+      this._spawnedCount++;
+      drained++;
+    }
+    return drained;
+  }
+
+  getSpawnQueueLength() {
+    return this._spawnQueue.length;
+  }
+
   _rndPos(playerPos, hRange, yBase, yRange) {
     return new THREE.Vector3(
       playerPos.x + (Math.random() - 0.5) * hRange,
@@ -276,18 +299,11 @@ export class CreatureManager {
   }
 
   update(dt, playerPos, depth) {
-    if (!this.initialized) {
-      this._spawnInitialCreatures(playerPos);
-    }
+    this.prepareInitialQueue(playerPos);
 
     // Drain spawn queue: 3 creatures per frame
     if (this._spawnQueue.length > 0) {
-      const batch = Math.min(3, this._spawnQueue.length);
-      for (let i = 0; i < batch; i++) {
-        const entry = this._spawnQueue.shift();
-        this._add(entry.type, entry.createFn(), entry.depthMin, entry.depthMax);
-        this._spawnedCount++;
-      }
+      this.preloadDrain(3);
     }
 
     this.lastDepth = depth;

--- a/src/environment/Flora.js
+++ b/src/environment/Flora.js
@@ -195,6 +195,78 @@ export class Flora {
     }
   }
 
+  _disposeGroup(group) {
+    group.traverse(child => {
+      if (child.geometry) child.geometry.dispose();
+      if (child.material) {
+        if (Array.isArray(child.material)) {
+          child.material.forEach(m => m.dispose());
+        } else {
+          child.material.dispose();
+        }
+      }
+    });
+    this.scene.remove(group);
+    this.kelps = this.kelps.filter(k => k.mesh.parent !== group);
+  }
+
+  _rebuildPendingAround(cx, cz) {
+    const needed = new Set();
+    for (let dx = -2; dx <= 2; dx++) {
+      for (let dz = -2; dz <= 2; dz++) {
+        needed.add(this._getChunkKey(cx + dx, cz + dz));
+      }
+    }
+
+    for (const [key, group] of this.groups) {
+      if (!needed.has(key)) {
+        this._disposeGroup(group);
+        this.groups.delete(key);
+      }
+    }
+
+    // Queue new chunks for staggered creation (1 per frame)
+    this._pendingChunks = [];
+    for (const key of needed) {
+      if (!this.groups.has(key)) {
+        const [x, z] = key.split(',').map(Number);
+        this._pendingChunks.push({ key, x, z });
+      }
+    }
+  }
+
+  preloadPrepareAround(playerPos) {
+    const cx = Math.round(playerPos.x / this.chunkSize);
+    const cz = Math.round(playerPos.z / this.chunkSize);
+    this.lastChunkX = cx;
+    this.lastChunkZ = cz;
+    this._rebuildPendingAround(cx, cz);
+  }
+
+  preloadDrain(maxCount, cancelToken) {
+    if (maxCount <= 0) return 0;
+    let built = 0;
+    while (this._pendingChunks.length > 0 && built < maxCount) {
+      if (cancelToken?.cancelled) break;
+      const { key, x, z } = this._pendingChunks.shift();
+      if (!this.groups.has(key)) {
+        const chunk = this._createFloraChunk(x, z);
+        this.scene.add(chunk);
+        this.groups.set(key, chunk);
+        built++;
+      }
+    }
+    return built;
+  }
+
+  getPendingCount() {
+    return this._pendingChunks.length;
+  }
+
+  getChunkCount() {
+    return this.groups.size;
+  }
+
   update(dt, playerPos) {
     this.time += dt;
 
@@ -215,42 +287,7 @@ export class Flora {
     if (cx !== this.lastChunkX || cz !== this.lastChunkZ) {
       this.lastChunkX = cx;
       this.lastChunkZ = cz;
-
-      const needed = new Set();
-      for (let dx = -2; dx <= 2; dx++) {
-        for (let dz = -2; dz <= 2; dz++) {
-          needed.add(this._getChunkKey(cx + dx, cz + dz));
-        }
-      }
-
-      for (const [key, group] of this.groups) {
-        if (!needed.has(key)) {
-          // Dispose geometries, materials, and lights before removing
-          group.traverse(child => {
-            if (child.geometry) child.geometry.dispose();
-            if (child.material) {
-              if (Array.isArray(child.material)) {
-                child.material.forEach(m => m.dispose());
-              } else {
-                child.material.dispose();
-              }
-            }
-          });
-          this.scene.remove(group);
-          this.groups.delete(key);
-          // Clean up kelp refs
-          this.kelps = this.kelps.filter(k => k.mesh.parent !== group);
-        }
-      }
-
-      // Queue new chunks for staggered creation (1 per frame)
-      this._pendingChunks = [];
-      for (const key of needed) {
-        if (!this.groups.has(key)) {
-          const [x, z] = key.split(',').map(Number);
-          this._pendingChunks.push({ key, x, z });
-        }
-      }
+      this._rebuildPendingAround(cx, cz);
     }
 
     // Animate kelp swaying

--- a/src/environment/Terrain.js
+++ b/src/environment/Terrain.js
@@ -122,24 +122,7 @@ export class Terrain {
     }
   }
 
-  update(playerPos) {
-    const cx = Math.round(playerPos.x / this.chunkSize);
-    const cz = Math.round(playerPos.z / this.chunkSize);
-
-    // Build at most 1 pending chunk per frame to avoid frame spikes
-    if (this._pendingChunks.length > 0) {
-      const { key, x, z } = this._pendingChunks.shift();
-      if (!this.chunks.has(key)) {
-        const chunk = this._createChunk(x, z);
-        this.scene.add(chunk);
-        this.chunks.set(key, chunk);
-      }
-    }
-
-    if (cx === this.lastChunkX && cz === this.lastChunkZ) return;
-    this.lastChunkX = cx;
-    this.lastChunkZ = cz;
-
+  _rebuildPendingAround(cx, cz) {
     const needed = new Set();
     for (let dx = -this.viewDistance; dx <= this.viewDistance; dx++) {
       for (let dz = -this.viewDistance; dz <= this.viewDistance; dz++) {
@@ -165,5 +148,57 @@ export class Terrain {
         this._pendingChunks.push({ key, x, z });
       }
     }
+  }
+
+  preloadPrepareAround(playerPos) {
+    const cx = Math.round(playerPos.x / this.chunkSize);
+    const cz = Math.round(playerPos.z / this.chunkSize);
+    this.lastChunkX = cx;
+    this.lastChunkZ = cz;
+    this._rebuildPendingAround(cx, cz);
+  }
+
+  preloadDrain(maxCount, cancelToken) {
+    if (maxCount <= 0) return 0;
+    let built = 0;
+    while (this._pendingChunks.length > 0 && built < maxCount) {
+      if (cancelToken?.cancelled) break;
+      const { key, x, z } = this._pendingChunks.shift();
+      if (!this.chunks.has(key)) {
+        const chunk = this._createChunk(x, z);
+        this.scene.add(chunk);
+        this.chunks.set(key, chunk);
+        built++;
+      }
+    }
+    return built;
+  }
+
+  getPendingCount() {
+    return this._pendingChunks.length;
+  }
+
+  getChunkCount() {
+    return this.chunks.size;
+  }
+
+  update(playerPos) {
+    const cx = Math.round(playerPos.x / this.chunkSize);
+    const cz = Math.round(playerPos.z / this.chunkSize);
+
+    // Build at most 1 pending chunk per frame to avoid frame spikes
+    if (this._pendingChunks.length > 0) {
+      const { key, x, z } = this._pendingChunks.shift();
+      if (!this.chunks.has(key)) {
+        const chunk = this._createChunk(x, z);
+        this.scene.add(chunk);
+        this.chunks.set(key, chunk);
+      }
+    }
+
+    if (cx === this.lastChunkX && cz === this.lastChunkZ) return;
+    this.lastChunkX = cx;
+    this.lastChunkZ = cz;
+    this._rebuildPendingAround(cx, cz);
   }
 }


### PR DESCRIPTION
## Summary
Implements issue #16 by adding a non-blocking menu-idle preload phase and procedural startup caching with strict fallback behavior.

## What changed
- Added explicit preload lifecycle coordinator (`idle -> warming -> cancelled|finalized`) in `src/PreloadCoordinator.js`.
- Added cancellation-token checks around expensive preload chunks and ensured Begin Descent always takes priority.
- Kept audio gesture-gated: preload does not initialize/resume audio.
- Added priority warmup tasks:
  - GPU warm-up
  - Creature initial queue prep + bounded pre-drain
  - Nearby terrain/flora precompute
  - Non-audio lookup precompute
- Added cache strategy and guardrails:
  - localStorage for tiny metadata pointers
  - IndexedDB for larger procedural snapshot payloads
  - Composite cache key invalidation: `gameVersion + worldSeed + qualityTier + schemaVersion`
  - LRU + TTL eviction, startup prune, size ceiling, write throttling
  - Graceful fallback for quota/indexeddb/read/write failures (memory-only session)
- Added bounded preload helper APIs to terrain/flora/creature managers.
- Wired preload startup/cancellation into `Game` transition flow.
- Documented behavior in `README.md`.

## Validation
- `npm run build` passes.

## Notes
- Preload never blocks Begin Descent.
- If preload is incomplete/cancelled, existing descent transition loading behavior continues unchanged.