### PR TITLE
feat: add keyboard navigation for creature locator

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,6 +188,11 @@
       font-size: 0.75rem;
     }
     .creature-entry:hover { background: #ffffff08; }
+    .creature-entry.selected {
+      background: #22ffcc1f;
+      border-left: 2px solid #22ffcc;
+      box-shadow: inset 0 0 0 1px #22ffcc44;
+    }
     .creature-entry.tracked { background: #22aaff15; border-left: 2px solid #22aaff; }
     .creature-key {
       width: 16px; height: 16px; display: flex; align-items: center;
@@ -305,7 +310,7 @@
     <div id="creature-locator">
       <h3>Creature Locator [C]</h3>
       <div id="creature-list"></div>
-      <div class="hint">Press 1-5 to track &bull; 0 to stop</div>
+      <div class="hint">Arrow keys select &bull; Enter tracks &bull; 1-9 quick track &bull; 0 stops</div>
     </div>
     <div id="track-indicator">
       <div id="track-arrow"><svg width="16" height="20" viewBox="0 0 16 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M8 0L15 13H10V20H6V13H1L8 0Z"/></svg></div>
@@ -335,6 +340,8 @@
         <h3>Interface</h3>
         <div class="help-row"><span class="help-key"><kbd>C</kbd></span><span class="help-desc">Creature locator</span></div>
         <div class="help-row"><span class="help-key"><kbd>1</kbd>-<kbd>9</kbd></span><span class="help-desc">Track creature</span></div>
+        <div class="help-row"><span class="help-key"><kbd>Up</kbd>/<kbd>Down</kbd></span><span class="help-desc">Select locator row</span></div>
+        <div class="help-row"><span class="help-key"><kbd>Enter</kbd></span><span class="help-desc">Track selected row</span></div>
         <div class="help-row"><span class="help-key"><kbd>0</kbd></span><span class="help-desc">Stop tracking</span></div>
         <div class="help-row"><span class="help-key"><kbd>H</kbd></span><span class="help-desc">Toggle this help</span></div>
         <div class="help-row"><span class="help-key"><kbd>Esc</kbd></span><span class="help-desc">Release mouse / Pause</span></div>

--- a/src/Game.js
+++ b/src/Game.js
@@ -99,6 +99,12 @@ export class Game {
       if (e.code === 'KeyC') this.hud.toggleLocator();
       if (e.code === 'Digit0') this.hud.stopTracking();
       if (this.hud.locatorVisible) {
+        if (this.hud.handleLocatorNavigation(e.code)) {
+          if (e.code === 'ArrowUp' || e.code === 'ArrowDown' || e.code === 'Enter') {
+            e.preventDefault();
+          }
+          return;
+        }
         const num = parseInt(e.key);
         if (num >= 1 && num <= 9) this.hud.trackCreature(num - 1);
       }

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -56,6 +56,8 @@ export class HUD {
     this.locatorVisible = false;
     this.trackedType = null;
     this.creatureTypes = [];
+    this.selectedCreatureType = null;
+    this.selectedCreatureIndex = -1;
 
     // Pickup notification
     this.pickupEl = document.createElement('div');
@@ -70,6 +72,8 @@ export class HUD {
     this.creatureList.addEventListener('click', (e) => {
       const entry = e.target.closest('.creature-entry');
       if (!entry || !entry.dataset.creatureType) return;
+      this.selectedCreatureType = entry.dataset.creatureType;
+      this.selectedCreatureIndex = this.creatureTypes.indexOf(this.selectedCreatureType);
       this.trackCreatureByType(entry.dataset.creatureType);
     });
   }
@@ -218,6 +222,7 @@ export class HUD {
 
   toggleLocator() {
     this.locatorVisible = !this.locatorVisible;
+    this._syncLocatorSelection();
     this.locatorPanel.classList.toggle('visible', this.locatorVisible);
   }
 
@@ -226,8 +231,72 @@ export class HUD {
     this.locatorPanel.classList.remove('visible');
   }
 
+  handleLocatorNavigation(code) {
+    if (!this.locatorVisible) return false;
+
+    if (code === 'ArrowUp') {
+      this._moveLocatorSelection(-1);
+      return true;
+    }
+    if (code === 'ArrowDown') {
+      this._moveLocatorSelection(1);
+      return true;
+    }
+    if (code === 'Enter') {
+      if (this.selectedCreatureType) {
+        this.trackCreatureByType(this.selectedCreatureType);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  _moveLocatorSelection(direction) {
+    const count = this.creatureTypes.length;
+    if (count === 0) {
+      this.selectedCreatureType = null;
+      this.selectedCreatureIndex = -1;
+      return;
+    }
+
+    this._syncLocatorSelection();
+    const current = this.selectedCreatureIndex >= 0 ? this.selectedCreatureIndex : 0;
+    const wrappedIndex = (current + direction + count) % count;
+    this.selectedCreatureIndex = wrappedIndex;
+    this.selectedCreatureType = this.creatureTypes[wrappedIndex];
+  }
+
+  _syncLocatorSelection() {
+    const count = this.creatureTypes.length;
+    if (count === 0) {
+      this.selectedCreatureType = null;
+      this.selectedCreatureIndex = -1;
+      return;
+    }
+
+    if (this.selectedCreatureType && this.creatureTypes.includes(this.selectedCreatureType)) {
+      this.selectedCreatureIndex = this.creatureTypes.indexOf(this.selectedCreatureType);
+      return;
+    }
+
+    if (this.trackedType && this.creatureTypes.includes(this.trackedType)) {
+      this.selectedCreatureType = this.trackedType;
+      this.selectedCreatureIndex = this.creatureTypes.indexOf(this.trackedType);
+      return;
+    }
+
+    const fallbackIndex = this.selectedCreatureIndex >= 0
+      ? Math.min(this.selectedCreatureIndex, count - 1)
+      : 0;
+    this.selectedCreatureIndex = fallbackIndex;
+    this.selectedCreatureType = this.creatureTypes[fallbackIndex];
+  }
+
   trackCreature(index) {
     if (index >= 0 && index < this.creatureTypes.length) {
+      this.selectedCreatureType = this.creatureTypes[index];
+      this.selectedCreatureIndex = index;
       this.trackCreatureByType(this.creatureTypes[index]);
     }
   }
@@ -262,12 +331,13 @@ export class HUD {
 
   _getLocatorHint() {
     return this.creatureTypes.length > 9
-      ? 'Press 1-9 to track the first nine. Click any row to track the rest. 0 stops tracking.'
-      : 'Press 1-9 to track. Click any row to track with the mouse. 0 stops tracking.';
+      ? 'Use Arrow keys to select and Enter to track. 1-9 track first nine, click any row to track the rest. 0 stops tracking.'
+      : 'Use Arrow keys to select and Enter to track. 1-9 track, click any row to track with the mouse. 0 stops tracking.';
   }
 
   updateLocator(creaturesByType, playerPos, camera) {
     this.creatureTypes = Object.keys(creaturesByType);
+    this._syncLocatorSelection();
     if (this.locatorHint) {
       this.locatorHint.textContent = this._getLocatorHint();
     }
@@ -280,7 +350,8 @@ export class HUD {
         const label = this._formatCreatureLabel(type);
         const dist = info.nearest < Infinity ? `${Math.floor(info.nearest)}m` : '---';
         const tracked = this.trackedType === type ? ' tracked' : '';
-        html += `<div class="creature-entry${tracked}" data-creature-type="${type}">` +
+        const selected = this.selectedCreatureType === type ? ' selected' : '';
+        html += `<div class="creature-entry${tracked}${selected}" data-creature-type="${type}">` +
           `<span class="creature-key">${i + 1}</span>` +
           `<span class="creature-name">${label}</span>` +
           `<span class="creature-count">x${info.count}</span>` +


### PR DESCRIPTION
## Summary
- add ArrowUp/ArrowDown keyboard navigation for Creature Locator rows with wrap-around
- add Enter to track the currently selected row
- preserve existing locator shortcuts: `1-9` to track indexed entries and `0` to stop tracking
- prevent default scroll behavior for Arrow keys/Enter while locator is open
- keep selection stable across creature list updates (spawn/despawn) by preferring selected type, then tracked type, then clamped index
- add visual highlight for keyboard-selected row and update locator/help text

## Validation
- `npm run build` (worktree: `F:\repos\deep-underworld-issue-20-locator-keyboard`) ✅

Closes #20