### PR TITLE
feat: tune atmosphere depth layering and abyss backdrop

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -321,51 +321,39 @@ export class Game {
     this._fogColor = new THREE.Color();
     this._envColorA = new THREE.Color();
     this._envColorB = new THREE.Color();
+    this._envColorC = new THREE.Color();
+    this._envColorD = new THREE.Color();
     this._fog = new THREE.Fog(0x006994, 5, 300);
     this.scene.fog = this._fog;
   }
 
   _updateEnvironmentForDepth(depth) {
-    // Fog and ambient light changes with depth
-    let fogNear, fogFar, ambientIntensity;
+    // Overlapping depth bands for smoother transitions without hard visual steps.
+    const twilight = THREE.MathUtils.smoothstep(depth, 35, 210);
+    const darkZone = THREE.MathUtils.smoothstep(depth, 170, 520);
+    const abyss = THREE.MathUtils.smoothstep(depth, 430, 900);
 
-    if (depth < 50) {
-      // Sunlit zone
-      const t = depth / 50;
-      this._envColorA.set(0x004466);
-      this._envColorB.set(0x002233);
-      this._fogColor.lerpColors(this._envColorA, this._envColorB, t);
-      fogNear = 5;
-      fogFar = THREE.MathUtils.lerp(200, 100, t);
-      ambientIntensity = THREE.MathUtils.lerp(0.25, 0.1, t);
-    } else if (depth < 200) {
-      // Twilight zone
-      const t = (depth - 50) / 150;
-      this._envColorA.set(0x002233);
-      this._envColorB.set(0x000811);
-      this._fogColor.lerpColors(this._envColorA, this._envColorB, t);
-      fogNear = 2;
-      fogFar = THREE.MathUtils.lerp(100, 45, t);
-      ambientIntensity = THREE.MathUtils.lerp(0.1, 0.015, t);
-    } else if (depth < 500) {
-      // Dark zone - nearly pitch black
-      const t = (depth - 200) / 300;
-      this._envColorA.set(0x000811);
-      this._envColorB.set(0x010104);
-      this._fogColor.lerpColors(this._envColorA, this._envColorB, t);
-      fogNear = 0.5;
-      fogFar = THREE.MathUtils.lerp(45, 22, t);
-      ambientIntensity = THREE.MathUtils.lerp(0.015, 0.002, t);
-    } else {
-      // Abyss - total darkness, only flashlight illuminates
-      const t = Math.min(1, (depth - 500) / 300);
-      this._envColorA.set(0x010104);
-      this._envColorB.set(0x000001);
-      this._fogColor.lerpColors(this._envColorA, this._envColorB, t);
-      fogNear = 0.1;
-      fogFar = THREE.MathUtils.lerp(22, 14, t);
-      ambientIntensity = THREE.MathUtils.lerp(0.002, 0.0003, t);
-    }
+    this._envColorA.set(0x004b70); // surface teal-blue
+    this._envColorB.set(0x001b2b); // twilight blue-black
+    this._envColorC.set(0x02060d); // dark zone indigo-black
+    this._envColorD.set(0x000205); // near-black abyss with faint blue for silhouettes
+
+    this._fogColor.copy(this._envColorA);
+    this._fogColor.lerp(this._envColorB, twilight);
+    this._fogColor.lerp(this._envColorC, darkZone);
+    this._fogColor.lerp(this._envColorD, abyss);
+
+    const nearTwilight = THREE.MathUtils.lerp(5.0, 1.6, twilight);
+    const nearDark = THREE.MathUtils.lerp(nearTwilight, 0.45, darkZone);
+    const fogNear = THREE.MathUtils.lerp(nearDark, 0.18, abyss);
+
+    const farTwilight = THREE.MathUtils.lerp(220, 82, twilight);
+    const farDark = THREE.MathUtils.lerp(farTwilight, 34, darkZone);
+    const fogFar = THREE.MathUtils.lerp(farDark, 19, abyss);
+
+    const ambientTwilight = THREE.MathUtils.lerp(0.24, 0.1, twilight);
+    const ambientDark = THREE.MathUtils.lerp(ambientTwilight, 0.025, darkZone);
+    const ambientIntensity = THREE.MathUtils.lerp(ambientDark, 0.006, abyss);
 
     this._fog.color.copy(this._fogColor);
     this._fog.near = fogNear;

--- a/src/environment/Ocean.js
+++ b/src/environment/Ocean.js
@@ -28,6 +28,8 @@ export class Ocean {
     this._createWaterSurface();
 
     // Floating particles (marine snow, plankton)
+    this.particleBaseSize = 0.15;
+    this.particleBaseOpacity = 0.35;
     this._createParticles();
 
     // Caustics light cookies near surface
@@ -97,11 +99,11 @@ export class Ocean {
     const snowTexture = new THREE.CanvasTexture(canvas);
 
     const mat = new THREE.PointsMaterial({
-      size: 0.15,
+      size: this.particleBaseSize,
       map: snowTexture,
       vertexColors: true,
       transparent: true,
-      opacity: 0.35,
+      opacity: this.particleBaseOpacity,
       blending: THREE.AdditiveBlending,
       depthWrite: false,
       sizeAttenuation: true,
@@ -157,6 +159,8 @@ export class Ocean {
 
   update(dt, depth, playerPos) {
     this.time += dt;
+    const depthBlend = THREE.MathUtils.smoothstep(depth, 45, 320);
+    const abyssBlend = THREE.MathUtils.smoothstep(depth, 380, 760);
 
     // Animate water surface
     const posAttr = this.waterSurface.geometry.attributes.position;
@@ -183,12 +187,24 @@ export class Ocean {
       const dy = ppos[i + 1] - playerPos.y;
       const dz = ppos[i + 2] - playerPos.z;
       if (dx * dx + dy * dy + dz * dz > 10000 || ppos[i + 1] > 0) {
-        ppos[i] = playerPos.x + (Math.random() - 0.5) * 150;
-        ppos[i + 1] = playerPos.y - Math.random() * 100 - 10;
-        ppos[i + 2] = playerPos.z + (Math.random() - 0.5) * 150;
+        const horizontalRadius = THREE.MathUtils.lerp(140, 85, depthBlend);
+        const verticalSpan = THREE.MathUtils.lerp(95, 180, depthBlend);
+        const abyssOffset = THREE.MathUtils.lerp(8, 30, abyssBlend);
+        ppos[i] = playerPos.x + (Math.random() - 0.5) * horizontalRadius;
+        ppos[i + 1] = playerPos.y - Math.random() * verticalSpan - abyssOffset;
+        ppos[i + 2] = playerPos.z + (Math.random() - 0.5) * horizontalRadius;
       }
     }
     this.particleSystem.geometry.attributes.position.needsUpdate = true;
+
+    // Denser, slightly larger snow in mid/deep water, then tighten in abyss for readability.
+    const deepOpacity = THREE.MathUtils.lerp(this.particleBaseOpacity * 0.68, this.particleBaseOpacity * 1.55, depthBlend);
+    const abyssFade = THREE.MathUtils.lerp(1.0, 0.86, abyssBlend);
+    this.particleSystem.material.opacity = deepOpacity * abyssFade;
+
+    const deepSize = THREE.MathUtils.lerp(this.particleBaseSize * 0.9, this.particleBaseSize * 1.45, depthBlend);
+    const abyssSizeClamp = THREE.MathUtils.lerp(1.0, 0.9, abyssBlend);
+    this.particleSystem.material.size = deepSize * abyssSizeClamp;
 
     // Animate caustic lights (only near surface)
     for (const c of this.causticLights) {

--- a/src/shaders/UnderwaterEffect.js
+++ b/src/shaders/UnderwaterEffect.js
@@ -34,6 +34,7 @@ const UnderwaterShader = {
       uv.y += cos(uv.x * 12.0 + time * 0.8) * distortStr * 0.6;
 
       vec4 color = texture2D(tDiffuse, uv);
+      vec2 fragCoord = uv * resolution;
 
       // Chromatic aberration (increases with depth)
       float caStr = 0.0015 + depth * 0.000005;
@@ -42,20 +43,19 @@ const UnderwaterShader = {
       color.r = r;
       color.b = b;
 
-      // Heavy vignette - pitch black edges in deep water
-      float vigBase = 0.4 + depth * 0.002;
-      float vigStr = min(vigBase, 2.5);
+      // Heavy vignette, but avoid crushing edge details into pure black.
+      float vigBase = 0.35 + depth * 0.0011;
+      float vigStr = min(vigBase, 0.82);
       vec2 center = uv - 0.5;
       float vigDist = dot(center, center);
-      float vignette = 1.0 - vigDist * vigStr;
-      vignette = smoothstep(0.0, 0.7, vignette);
-      color.rgb *= vignette;
+      float vignette = 1.0 - smoothstep(0.12, 0.42, vigDist) * vigStr;
+      color.rgb *= max(vignette, 0.22);
 
       // Color grading - deep ocean tint
       float depthT = clamp(depth / 400.0, 0.0, 1.0);
       vec3 shallowTint = vec3(0.65, 0.8, 1.0);
-      vec3 deepTint = vec3(0.15, 0.1, 0.25);
-      vec3 abyssTint = vec3(0.05, 0.03, 0.08);
+      vec3 deepTint = vec3(0.14, 0.21, 0.29);
+      vec3 abyssTint = vec3(0.045, 0.08, 0.11);
       vec3 tint = depthT < 0.5
         ? mix(shallowTint, deepTint, depthT * 2.0)
         : mix(deepTint, abyssTint, (depthT - 0.5) * 2.0);
@@ -65,15 +65,28 @@ const UnderwaterShader = {
       float darkening = 1.0 - clamp(depth / 600.0, 0.0, 0.6);
       color.rgb *= darkening;
 
+      // Preserve faint hero silhouettes in abyss by gently lifting midtones.
+      float abyssBlend = smoothstep(220.0, 760.0, depth);
+      float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
+      float silhouetteLift = smoothstep(0.04, 0.32, luma) * 0.025 * abyssBlend;
+      color.rgb += silhouetteLift;
+
       // Film grain - heavier for oppressive atmosphere
       float grainStr = 0.025 + depth * 0.00005;
       float grain = fract(sin(dot(uv * time * 0.01, vec2(12.9898, 78.233))) * 43758.5453);
       color.rgb += (grain - 0.5) * grainStr;
 
+      // Ordered dither in darker gradients helps break visible color banding.
+      float dither = fract(52.9829189 * fract(dot(fragCoord, vec2(0.06711056, 0.00583715)) + time * 0.003));
+      float ditherStrength = mix(0.0018, 0.008, abyssBlend);
+      color.rgb += (dither - 0.5) * ditherStrength;
+
       // Slight scanline effect for deep water dread
       float scanline = 0.97 + 0.03 * sin(uv.y * resolution.y * 1.5);
       float scanlineStr = clamp(depth / 500.0, 0.0, 1.0) * 0.4;
       color.rgb *= mix(1.0, scanline, scanlineStr);
+
+      color.rgb = clamp(color.rgb, 0.0, 1.0);
 
       gl_FragColor = color;
     }


### PR DESCRIPTION
## Summary
- tune marine snow depth bands with denser mid/deep-water distribution and depth-aware scale/opacity
- smooth twilight-to-abyss fog transitions with overlapping depth-band interpolation
- refine abyss background/falloff toward near-black while preserving silhouette readability
- add shader-side dark-gradient dithering to reduce visible banding artifacts

## Validation
- npm run build

Closes #24