### PR TITLE
fix: remove flashlight shadow map to eliminate F-key UI stutter

### DIFF
--- a/src/player/Player.js
+++ b/src/player/Player.js
@@ -38,8 +38,6 @@ export class Player {
     // Submarine flashlight
     this.flashlight = new THREE.Group();
     const spotlight = new THREE.SpotLight(0xccddff, 50, 80, Math.PI / 7, 0.3, 1.8);
-    spotlight.castShadow = true;
-    spotlight.shadow.mapSize.set(1024, 1024);
     spotlight.position.set(0, 0, 0);
     spotlight.target.position.set(0, 0, -1);
     this.flashlight.add(spotlight);


### PR DESCRIPTION
## Problem

Pressing **F** (flashlight toggle) for the first time caused a multi-second UI freeze/stutter. 

**Root cause:** The flashlight `SpotLight` in `src/player/Player.js` had `castShadow = true` and a 1024×1024 shadow map configured:

```js
spotlight.castShadow = true;
spotlight.shadow.mapSize.set(1024, 1024);
```

Three.js defers shadow map allocation until the light first becomes visible. On the first F keypress, Three.js allocates and compiles the shadow render target on the GPU, causing a blocking stall that locks the UI for several seconds.

## Fix

Removed the two shadow-casting lines from the `SpotLight` setup:

```diff
- spotlight.castShadow = true;
- spotlight.shadow.mapSize.set(1024, 1024);
```

Underwater flashlight shadows are not perceptible to the player (the beam cone visual already provides the depth cue), so removing them has no visible impact while eliminating the GPU stall entirely.

## Validation

- `npm run build` passes cleanly
- No visual regression: the volumetric cone and spotlight illumination are unchanged