### PR TITLE
fix: correct compass arrow rotation and add vertical elevation indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,7 @@
     #track-info { display: flex; flex-direction: column; gap: 1px; }
     #track-name { color: #88ccff; font-size: 0.7rem; }
     #track-dist { color: #448866; font-size: 0.65rem; }
+    #track-elev { color: #6688aa; font-size: 0.65rem; }
 
     /* Controls Help Overlay */
     #controls-help {
@@ -317,6 +318,7 @@
       <div id="track-info">
         <span id="track-name"></span>
         <span id="track-dist"></span>
+        <span id="track-elev"></span>
       </div>
     </div>
   </div>

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -52,6 +52,7 @@ export class HUD {
     this.trackArrow = document.getElementById('track-arrow');
     this.trackName = document.getElementById('track-name');
     this.trackDist = document.getElementById('track-dist');
+    this.trackElev = document.getElementById('track-elev');
     this.locatorHint = this.locatorPanel.querySelector('.hint');
     this.locatorVisible = false;
     this.trackedType = null;
@@ -375,8 +376,17 @@ export class HUD {
         camera.getWorldDirection(forward);
 
         // Horizontal angle between camera forward and creature direction
-        const angle = Math.atan2(dir.x, dir.z) - Math.atan2(forward.x, forward.z);
+        const angle = Math.atan2(forward.x, forward.z) - Math.atan2(dir.x, dir.z);
         this.trackArrow.style.transform = `rotate(${angle}rad)`;
+
+        // Vertical elevation indicator
+        const dy = dir.y;
+        if (Math.abs(dy) >= 3) {
+          const sym = dy > 0 ? '▲' : '▼';
+          this.trackElev.textContent = `${sym} ${Math.floor(Math.abs(dy))}m`;
+        } else {
+          this.trackElev.textContent = '';
+        }
       } else {
         this.trackedType = null;
         this.trackIndicator.classList.remove('visible');


### PR DESCRIPTION
## Changes

**1. Fix inverted compass arrow rotation**

The creature tracking compass arrow was rotating in the same direction as the player instead of pointing toward the tracked creature. Swapped the `atan2` operands so the angle is computed as `forward - direction` instead of `direction - forward`.

**2. Add vertical elevation indicator**

The compass now shows whether the tracked creature is above (▲) or below (▼) the player, along with the vertical distance in meters. A new `#track-elev` span is rendered next to distance info. Differences under 3m are hidden to avoid noise.

### Files changed
- `src/ui/HUD.js` — Fixed angle calculation, added `trackElev` DOM cache and elevation display logic
- `index.html` — Added `#track-elev` element and CSS styling