### PR TITLE
feat: tune render pipeline for depth contrast and highlight retention

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -24,7 +24,7 @@ export class Game {
     this.renderer.shadowMap.enabled = true;
     this.renderer.shadowMap.type = THREE.PCFShadowMap;
     this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-    this.renderer.toneMappingExposure = 0.8;
+    this.renderer.toneMappingExposure = 0.76;
     this.renderer.outputColorSpace = THREE.SRGBColorSpace;
     this.renderer.domElement.id = 'game-canvas';
     this.renderer.domElement.dataset.testid = 'game-canvas';
@@ -45,6 +45,23 @@ export class Game {
     this.audio = new AudioManager();
     this.underwaterEffect = new UnderwaterEffect(this.renderer, this.scene, this.camera);
     this.abyssEncounter = new AbyssEncounter();
+
+    this.renderTuning = {
+      depthThresholds: {
+        mid: 120,
+        deep: 340,
+        abyss: 700,
+      },
+      exposure: {
+        surface: 0.76,
+        mid: 0.66,
+        deep: 0.55,
+        abyss: 0.48,
+        flashlightBoost: 0.08,
+        easing: 0.08,
+      },
+    };
+    this._targetExposure = this.renderer.toneMappingExposure;
 
     // Alias so automated tests can use game.creatureManager or game.creatures
     this.creatureManager = this.creatures;
@@ -295,6 +312,7 @@ export class Game {
 
     // Update underwater fog based on depth, then let encounter override if active
     this._updateEnvironmentForDepth(depth);
+    this._updateRenderPipelineForDepth(depth);
     this.abyssEncounter.update(dt, depth, this.player, this.scene, this._fog, this.ocean.ambientLight, this.hud);
 
     // Keep descent assist pumping in both regular and autoplay starts.
@@ -318,7 +336,10 @@ export class Game {
     }
 
     // Render with post-processing
-    this.underwaterEffect.render(depth);
+    this.underwaterEffect.render(depth, {
+      flashlightOn: this.flashlightOn,
+      exposure: this.renderer.toneMappingExposure,
+    });
     } catch (err) {
       console.error('[deep-underworld] Animation frame error:', err);
     }
@@ -368,5 +389,30 @@ export class Game {
     this._fog.far = fogFar;
     this.scene.background.copy(this._fogColor);
     this.ocean.ambientLight.intensity = ambientIntensity;
+  }
+
+  _updateRenderPipelineForDepth(depth) {
+    const thresholds = this.renderTuning.depthThresholds;
+    const exposure = this.renderTuning.exposure;
+
+    const midBlend = THREE.MathUtils.smoothstep(depth, thresholds.mid, thresholds.deep);
+    const deepBlend = THREE.MathUtils.smoothstep(depth, thresholds.deep, thresholds.abyss);
+
+    let target = THREE.MathUtils.lerp(exposure.surface, exposure.mid, midBlend);
+    target = THREE.MathUtils.lerp(target, exposure.deep, deepBlend);
+
+    const abyssBlend = THREE.MathUtils.smoothstep(depth, thresholds.abyss, thresholds.abyss + 280);
+    target = THREE.MathUtils.lerp(target, exposure.abyss, abyssBlend);
+
+    if (this.flashlightOn) {
+      target += exposure.flashlightBoost;
+    }
+
+    this._targetExposure = THREE.MathUtils.clamp(target, 0.42, 0.9);
+    this.renderer.toneMappingExposure = THREE.MathUtils.lerp(
+      this.renderer.toneMappingExposure,
+      this._targetExposure,
+      exposure.easing
+    );
   }
 }

--- a/src/shaders/UnderwaterEffect.js
+++ b/src/shaders/UnderwaterEffect.js
@@ -4,12 +4,44 @@ import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 
+const RENDER_PIPELINE_TUNING = Object.freeze({
+  depthThresholds: {
+    mid: 130,
+    deep: 340,
+    abyss: 720,
+  },
+  grading: {
+    contrast: 1.2,
+    vignette: 0.88,
+    grain: 0.018,
+    scanline: 0.24,
+    darkening: 0.68,
+  },
+  highlightRoll: {
+    start: 0.62,
+    range: 0.34,
+    strength: 0.62,
+  },
+  bloom: {
+    surfaceStrength: 0.28,
+    deepStrength: 0.82,
+    surfaceThreshold: 0.78,
+    deepThreshold: 0.44,
+    radius: 0.62,
+  },
+});
+
 const UnderwaterShader = {
   uniforms: {
     tDiffuse: { value: null },
     time: { value: 0 },
     depth: { value: 0 },
+    exposure: { value: 0.76 },
     resolution: { value: new THREE.Vector2() },
+    depthThresholds: { value: new THREE.Vector3(130, 340, 720) },
+    grading: { value: new THREE.Vector4(1.2, 0.88, 0.018, 0.24) },
+    darkening: { value: 0.68 },
+    highlightRoll: { value: new THREE.Vector3(0.62, 0.34, 0.62) },
   },
   vertexShader: `
     varying vec2 vUv;
@@ -22,7 +54,12 @@ const UnderwaterShader = {
     uniform sampler2D tDiffuse;
     uniform float time;
     uniform float depth;
+    uniform float exposure;
     uniform vec2 resolution;
+    uniform vec3 depthThresholds;
+    uniform vec4 grading;
+    uniform float darkening;
+    uniform vec3 highlightRoll;
     varying vec2 vUv;
 
     void main() {
@@ -35,6 +72,10 @@ const UnderwaterShader = {
 
       vec4 color = texture2D(tDiffuse, uv);
       vec2 fragCoord = uv * resolution;
+      float midBlend = smoothstep(depthThresholds.x, depthThresholds.y, depth);
+      float deepBlend = smoothstep(depthThresholds.y, depthThresholds.z, depth);
+      float abyssBlend = smoothstep(depthThresholds.z, depthThresholds.z + 280.0, depth);
+      float depthBlend = clamp(midBlend * 0.45 + deepBlend * 0.7 + abyssBlend * 0.35, 0.0, 1.0);
 
       // Chromatic aberration (increases with depth)
       float caStr = 0.0015 + depth * 0.000005;
@@ -44,47 +85,57 @@ const UnderwaterShader = {
       color.b = b;
 
       // Heavy vignette, but avoid crushing edge details into pure black.
-      float vigBase = 0.35 + depth * 0.0011;
-      float vigStr = min(vigBase, 0.82);
+      float vigBase = 0.28 + depthBlend * grading.y;
+      float vigStr = min(vigBase, 0.9);
       vec2 center = uv - 0.5;
       float vigDist = dot(center, center);
       float vignette = 1.0 - smoothstep(0.12, 0.42, vigDist) * vigStr;
-      color.rgb *= max(vignette, 0.22);
+      color.rgb *= max(vignette, 0.2);
 
       // Color grading - deep ocean tint
-      float depthT = clamp(depth / 400.0, 0.0, 1.0);
+      float depthT = clamp(depth / (depthThresholds.z * 0.75), 0.0, 1.0);
       vec3 shallowTint = vec3(0.65, 0.8, 1.0);
-      vec3 deepTint = vec3(0.14, 0.21, 0.29);
-      vec3 abyssTint = vec3(0.045, 0.08, 0.11);
+      vec3 deepTint = vec3(0.12, 0.19, 0.27);
+      vec3 abyssTint = vec3(0.038, 0.068, 0.1);
       vec3 tint = depthT < 0.5
         ? mix(shallowTint, deepTint, depthT * 2.0)
         : mix(deepTint, abyssTint, (depthT - 0.5) * 2.0);
       color.rgb *= tint;
 
-      // Darken overall based on depth
-      float darkening = 1.0 - clamp(depth / 600.0, 0.0, 0.6);
-      color.rgb *= darkening;
+      // Darken overall based on depth while preserving flashlight readability.
+      float depthDarkening = 1.0 - depthBlend * darkening;
+      color.rgb *= max(depthDarkening, 0.28);
+
+      // Depth-aware contrast to strengthen separation in mid/deep zones.
+      float contrast = mix(1.0, grading.x, depthBlend);
+      color.rgb = (color.rgb - 0.18) * contrast + 0.18;
 
       // Preserve faint hero silhouettes in abyss by gently lifting midtones.
-      float abyssBlend = smoothstep(220.0, 760.0, depth);
       float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
-      float silhouetteLift = smoothstep(0.04, 0.32, luma) * 0.025 * abyssBlend;
+      float silhouetteLift = smoothstep(0.04, 0.32, luma) * 0.022 * abyssBlend;
       color.rgb += silhouetteLift;
 
       // Film grain - heavier for oppressive atmosphere
-      float grainStr = 0.025 + depth * 0.00005;
+      float grainStr = grading.z + depthBlend * 0.02;
       float grain = fract(sin(dot(uv * time * 0.01, vec2(12.9898, 78.233))) * 43758.5453);
       color.rgb += (grain - 0.5) * grainStr;
 
       // Ordered dither in darker gradients helps break visible color banding.
       float dither = fract(52.9829189 * fract(dot(fragCoord, vec2(0.06711056, 0.00583715)) + time * 0.003));
-      float ditherStrength = mix(0.0018, 0.008, abyssBlend);
+      float ditherStrength = mix(0.0016, 0.0065, abyssBlend);
       color.rgb += (dither - 0.5) * ditherStrength;
 
       // Slight scanline effect for deep water dread
       float scanline = 0.97 + 0.03 * sin(uv.y * resolution.y * 1.5);
-      float scanlineStr = clamp(depth / 500.0, 0.0, 1.0) * 0.4;
+      float scanlineStr = clamp(depthBlend, 0.0, 1.0) * grading.w;
       color.rgb *= mix(1.0, scanline, scanlineStr);
+
+      // Highlight roll-off reduces flashlight hotspot clipping while keeping punch.
+      float peak = max(max(color.r, color.g), color.b);
+      float rollStart = max(0.45, highlightRoll.x - exposure * 0.08);
+      float rollBlend = smoothstep(rollStart, rollStart + highlightRoll.y, peak) * highlightRoll.z;
+      vec3 rolled = color.rgb / (1.0 + color.rgb);
+      color.rgb = mix(color.rgb, rolled, rollBlend);
 
       color.rgb = clamp(color.rgb, 0.0, 1.0);
 
@@ -102,6 +153,7 @@ export class UnderwaterEffect {
 
     // Composer
     this.composer = new EffectComposer(renderer);
+    this.tuning = RENDER_PIPELINE_TUNING;
 
     // Render pass
     const renderPass = new RenderPass(scene, camera);
@@ -110,15 +162,32 @@ export class UnderwaterEffect {
     // Bloom for bioluminescent glow
     this.bloomPass = new UnrealBloomPass(
       new THREE.Vector2(window.innerWidth, window.innerHeight),
-      0.4,  // strength - lower base, bloom stands out more in darkness
-      0.6,  // radius - wider bloom spread
-      0.7   // threshold - lower to pick up dim bioluminescence
+      this.tuning.bloom.surfaceStrength,
+      this.tuning.bloom.radius,
+      this.tuning.bloom.surfaceThreshold
     );
     this.composer.addPass(this.bloomPass);
 
     // Underwater shader
     this.underwaterPass = new ShaderPass(UnderwaterShader);
     this.underwaterPass.uniforms.resolution.value.set(window.innerWidth, window.innerHeight);
+    this.underwaterPass.uniforms.depthThresholds.value.set(
+      this.tuning.depthThresholds.mid,
+      this.tuning.depthThresholds.deep,
+      this.tuning.depthThresholds.abyss
+    );
+    this.underwaterPass.uniforms.grading.value.set(
+      this.tuning.grading.contrast,
+      this.tuning.grading.vignette,
+      this.tuning.grading.grain,
+      this.tuning.grading.scanline
+    );
+    this.underwaterPass.uniforms.darkening.value = this.tuning.grading.darkening;
+    this.underwaterPass.uniforms.highlightRoll.value.set(
+      this.tuning.highlightRoll.start,
+      this.tuning.highlightRoll.range,
+      this.tuning.highlightRoll.strength
+    );
     this.composer.addPass(this.underwaterPass);
 
     // Adaptive bloom guard:
@@ -132,20 +201,33 @@ export class UnderwaterEffect {
     this.underwaterPass.uniforms.resolution.value.set(window.innerWidth, window.innerHeight);
   }
 
-  render(depth) {
+  render(depth, { flashlightOn = false, exposure = 0.76 } = {}) {
     const frameStart = performance.now();
     this.time += 0.016;
     this.underwaterPass.uniforms.time.value = this.time;
     this.underwaterPass.uniforms.depth.value = depth;
+    this.underwaterPass.uniforms.exposure.value = exposure;
 
-    // Increase bloom in deep zones (bioluminescence and flashlight stand out more)
-    if (depth > 200) {
-      this.bloomPass.strength = Math.min(1.1, 0.7 + (depth - 200) / 400 * 0.8);
-      this.bloomPass.threshold = Math.max(0.3, 0.7 - depth / 1000);
-    } else {
-      this.bloomPass.strength = 0.4;
-      this.bloomPass.threshold = 0.7;
-    }
+    const depthNorm = THREE.MathUtils.smoothstep(
+      depth,
+      this.tuning.depthThresholds.mid,
+      this.tuning.depthThresholds.abyss
+    );
+
+    const targetStrength = THREE.MathUtils.lerp(
+      this.tuning.bloom.surfaceStrength,
+      this.tuning.bloom.deepStrength,
+      depthNorm
+    ) * (flashlightOn ? 0.88 : 1.0);
+
+    const targetThreshold = THREE.MathUtils.lerp(
+      this.tuning.bloom.surfaceThreshold,
+      this.tuning.bloom.deepThreshold,
+      depthNorm
+    ) + (flashlightOn ? 0.08 : 0.0);
+
+    this.bloomPass.strength = THREE.MathUtils.lerp(this.bloomPass.strength, targetStrength, 0.09);
+    this.bloomPass.threshold = THREE.MathUtils.lerp(this.bloomPass.threshold, targetThreshold, 0.09);
 
     const now = performance.now();
     this.bloomPass.enabled = now >= this._bloomSuppressedUntil;


### PR DESCRIPTION
## Summary
- add depth-threshold tuning constants for exposure and underwater post grading
- rebalance tone-mapping exposure and bloom interaction across depth bands
- refine underwater shader grading (contrast, vignette, grain, scanlines) with depth-aware controls
- add highlight roll-off in post to keep flashlight hotspots detailed instead of clipping

## Validation
- npm run build

Fixes #23