### PR TITLE
fix: dismiss descent overlay after startup priming completes

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -283,6 +283,16 @@ export class Game {
 
     this.preload.startDescentAssistFromSnapshot();
 
+    // Dismiss descent overlay now that priming is complete.
+    // The depth-gated spawn queue may never fully drain at shallow depth,
+    // so we dismiss here rather than waiting for isFullyLoaded().
+    this._descentActive = false;
+    this.descentOverlay.classList.add('fade-out');
+    setTimeout(() => {
+      this.descentOverlay.classList.remove('visible');
+      this.descentOverlay.classList.remove('fade-out');
+    }, 800);
+
     // Warm-up render to force shader compilation before gameplay.
     this.underwaterEffect.render(0);
 
@@ -368,18 +378,15 @@ export class Game {
     // Keep descent assist pumping in both regular and autoplay starts.
     this.preload.pumpDescentAssist();
 
-    // Update descent transition overlay
+    // Safety-net: dismiss descent overlay if still active (normally handled in _primeAndEnterGameplay)
     if (this._descentActive) {
-      const progress = this.creatures.getLoadProgress();
       this._updateDescentProgress();
-      if (this.creatures.isFullyLoaded()) {
-        this._descentActive = false;
-        this.descentOverlay.classList.add('fade-out');
-        setTimeout(() => {
-          this.descentOverlay.classList.remove('visible');
-          this.descentOverlay.classList.remove('fade-out');
-        }, 800);
-      }
+      this._descentActive = false;
+      this.descentOverlay.classList.add('fade-out');
+      setTimeout(() => {
+        this.descentOverlay.classList.remove('visible');
+        this.descentOverlay.classList.remove('fade-out');
+      }, 800);
     }
 
     // Render with post-processing


### PR DESCRIPTION
## Problem

The "Descending..." overlay never disappears after starting the game.

## Root Cause

The descent overlay was shown in `_primeAndEnterGameplay()` and dismissed in `_animate()` only when `this.creatures.isFullyLoaded()` returned true. `isFullyLoaded()` requires `_spawnQueue.length === 0` (all creatures spawned). However, `preloadDrain()` during gameplay is depth-gated — it only spawns creatures where `depthMin <= currentDepth + 45`. Since the player starts near the surface (depth ~0), deep creatures (200m+, 300m+, 500m+) never drain from the queue. The queue is never empty, so `isFullyLoaded()` never returns true, and the overlay stays forever.

## Fix

1. **In `_primeAndEnterGameplay()`**: Dismiss the descent overlay immediately after `primeStartBaseline()` completes and `startDescentAssistFromSnapshot()` is called, before setting `this.running = true`. This is the correct point — priming is done and gameplay is about to begin.

2. **In `_animate()`**: Simplified the descent overlay check to a safety-net that immediately dismisses it if still active (no `isFullyLoaded()` gate). This handles any edge case where the overlay wasn't dismissed during priming.