### PR TITLE
perf: reduce startup hitching and first-use stalls

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -339,13 +339,20 @@ export class Game {
   }
 
   _updateDescentProgress() {
-    const progress = this.creatures.getLoadProgress();
-    if (progress.total <= 0) {
-      this.descentProgressBar.style.width = '0%';
-      return;
-    }
+    // Composite progress: creatures 50%, terrain 25%, flora 25%
+    const creatures = this.creatures.getLoadProgress();
+    const terrainPending = this.terrain.getPendingCount();
+    const terrainLoaded = this.terrain.getChunkCount();
+    const terrainTotal = terrainLoaded + terrainPending;
+    const floraPending = this.flora.getPendingCount();
+    const floraLoaded = this.flora.getChunkCount();
+    const floraTotal = floraLoaded + floraPending;
 
-    const pct = Math.min(100, (progress.loaded / progress.total) * 100);
+    const creaturePct = creatures.total > 0 ? creatures.loaded / creatures.total : 1;
+    const terrainPct = terrainTotal > 0 ? terrainLoaded / terrainTotal : 1;
+    const floraPct = floraTotal > 0 ? floraLoaded / floraTotal : 1;
+
+    const pct = Math.min(100, (creaturePct * 0.5 + terrainPct * 0.25 + floraPct * 0.25) * 100);
     this.descentProgressBar.style.width = pct + '%';
   }
 

--- a/src/PreloadCoordinator.js
+++ b/src/PreloadCoordinator.js
@@ -255,8 +255,19 @@ export class PreloadCoordinator {
 
     this.renderer.compile(this.underwaterEffect.scene, this.underwaterEffect.camera);
     this.underwaterEffect.render(0);
+
+    // Warm flashlight materials so first toggle doesn't cause a shader-compile hitch
+    this._warmFlashlightOnce();
+
     this._gpuWarmed = true;
     return true;
+  }
+
+  _warmFlashlightOnce() {
+    const wasVisible = this.player.flashlight.visible;
+    this.player.flashlight.visible = true;
+    this.renderer.compile(this.underwaterEffect.scene, this.underwaterEffect.camera);
+    this.player.flashlight.visible = wasVisible;
   }
 
   _warmCreatureQueue(token) {

--- a/src/audio/AudioManager.js
+++ b/src/audio/AudioManager.js
@@ -35,6 +35,12 @@ export class AudioManager {
     this.sonarOsc = null;
   }
 
+  /**
+   * Phase 1 (synchronous): Create AudioContext, master chain, and buses.
+   * Must run inside a user-gesture context. Heavy work (noise buffers,
+   * drones, texture bed, MusicSystem) is deferred to budgeted async phases
+   * so the main thread is not blocked.
+   */
   start() {
     if (this.started) return;
     const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
@@ -53,19 +59,44 @@ export class AudioManager {
     this.musicBus = this._createBus(this.busDefaults.music);
     this.threatBus = this._createBus(this.busDefaults.threat);
     this.uiBus = this._createBus(this.busDefaults.ui);
-    this.noiseBuffers = {
-      white: this._createNoiseBuffer(2.5, 'white'),
-      pink: this._createNoiseBuffer(2.5, 'pink'),
-      brown: this._createNoiseBuffer(2.5, 'brown'),
-    };
     this.started = true;
 
-    this._createDrone(34, 'sine', 0.042);
-    this._createDrone(49, 'triangle', 0.026);
-    this._createDrone(73, 'sine', 0.011);
-    this._createDrone(22, 'sine', 0.03);
+    // Kick off budgeted async build — audio layers will fade in gradually
+    this._asyncBuildPromise = this._buildAudioGraphAsync();
+  }
+
+  /**
+   * Phase 2+ (async, budgeted): Generate noise buffers, drones, texture bed,
+   * and MusicSystem layers in small incremental steps, yielding to the
+   * browser between phases so startup is not blocked.
+   */
+  async _buildAudioGraphAsync() {
+    // Phase 2: Noise buffers (one per frame yield)
+    const colors = ['white', 'pink', 'brown'];
+    this.noiseBuffers = {};
+    for (const color of colors) {
+      this.noiseBuffers[color] = this._createNoiseBuffer(2.5, color);
+      await new Promise(r => requestAnimationFrame(r));
+    }
+
+    // Phase 3: Drones (batch in pairs, yield between)
+    const droneSpecs = [
+      [34, 'sine', 0.042],
+      [49, 'triangle', 0.026],
+      [73, 'sine', 0.011],
+      [22, 'sine', 0.03],
+    ];
+    for (let i = 0; i < droneSpecs.length; i++) {
+      this._createDrone(...droneSpecs[i]);
+      if (i % 2 === 1) await new Promise(r => requestAnimationFrame(r));
+    }
+
+    // Phase 4: Texture bed
+    await new Promise(r => requestAnimationFrame(r));
     this._initTextureBed();
 
+    // Phase 5: MusicSystem (constructor builds all layers)
+    await new Promise(r => requestAnimationFrame(r));
     this.music = new MusicSystem(this.ctx, {
       music: this.musicBus,
       threat: this.threatBus,

--- a/src/player/Player.js
+++ b/src/player/Player.js
@@ -110,6 +110,12 @@ export class Player {
     /** Current depth (positive = deeper). Updated by Game._animate(). */
     this.depth = 0;
 
+    // Reusable vectors for update() — avoids per-frame allocations
+    this._forward = new THREE.Vector3();
+    this._right = new THREE.Vector3();
+    this._up = new THREE.Vector3(0, 1, 0);
+    this._accel = new THREE.Vector3();
+
     // Head bobbing
     this.bobTime = 0;
     this.bobAmount = 0.03;
@@ -210,27 +216,26 @@ export class Player {
   update(dt) {
     if (!this.locked) return;
 
-    const forward = new THREE.Vector3();
-    this.camera.getWorldDirection(forward);
-    const right = new THREE.Vector3().crossVectors(forward, this.camera.up).normalize();
-    const up = new THREE.Vector3(0, 1, 0);
+    this.camera.getWorldDirection(this._forward);
+    this._right.crossVectors(this._forward, this.camera.up).normalize();
+    this._up.set(0, 1, 0);
 
-    const accel = new THREE.Vector3();
+    this._accel.set(0, 0, 0);
 
-    if (this.keys['KeyW']) accel.add(forward);
-    if (this.keys['KeyS']) accel.sub(forward);
-    if (this.keys['KeyA']) accel.sub(right);
-    if (this.keys['KeyD']) accel.add(right);
-    if (this.keys['Space']) accel.add(up);
-    if (this.keys['ShiftLeft'] || this.keys['ShiftRight']) accel.sub(up);
+    if (this.keys['KeyW']) this._accel.add(this._forward);
+    if (this.keys['KeyS']) this._accel.sub(this._forward);
+    if (this.keys['KeyA']) this._accel.sub(this._right);
+    if (this.keys['KeyD']) this._accel.add(this._right);
+    if (this.keys['Space']) this._accel.add(this._up);
+    if (this.keys['ShiftLeft'] || this.keys['ShiftRight']) this._accel.sub(this._up);
 
-    if (accel.length() > 0) {
-      accel.normalize().multiplyScalar(this.moveSpeed);
+    if (this._accel.length() > 0) {
+      this._accel.normalize().multiplyScalar(this.moveSpeed);
     }
 
-    this.velocity.add(accel.multiplyScalar(dt));
+    this.velocity.add(this._accel.multiplyScalar(dt));
     this.velocity.multiplyScalar(1 - this.dampening * dt);
-    this.position.add(this.velocity.clone().multiplyScalar(dt));
+    this.position.addScaledVector(this.velocity, dt);
 
     // Keep player below water surface
     if (this.position.y > -1) {


### PR DESCRIPTION
## Summary

Fixes #51 — Reduce remaining startup hitching and first-use stalls.

### Changes

#### 1. Budgeted audio startup
`AudioManager.start()` now only creates the AudioContext, master chain, and buses synchronously (the minimum needed in user-gesture context). Heavy work — noise buffer generation, drone creation, texture bed, and MusicSystem construction — is deferred to `_buildAudioGraphAsync()` which yields to the browser between each phase via `requestAnimationFrame`. Missing the first few seconds of ambient layers is acceptable since the player is just descending.

#### 2. Flashlight first-use warmup
Added `_warmFlashlightOnce()` in `PreloadCoordinator._warmGpuOnce()`. This temporarily makes the flashlight group visible, calls `renderer.compile()` to force shader compilation, then restores visibility. First flashlight toggle no longer triggers a shader-compile hitch.

#### 3. Player.update() allocation cleanup
Replaced four `new THREE.Vector3()` allocations per frame with reusable class fields (`_forward`, `_right`, `_up`, `_accel`) initialized in the constructor. Replaced `this.velocity.clone().multiplyScalar(dt)` with `this.position.addScaledVector(this.velocity, dt)`.

#### 4. Composite startup progress UI
`_updateDescentProgress()` now computes a weighted composite: 50% creatures, 25% terrain, 25% flora — using the existing `getLoadProgress()`, `getPendingCount()`, and `getChunkCount()` APIs.

### Validation
- `npm run build` passes
- No changes to autoplay, pointer-lock fallback, or preload cancellation behavior