### PR TITLE
feat: add Rapier3D collision detection for terrain and rocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "deep-underworld",
       "version": "1.0.0",
       "dependencies": {
+        "@dimforge/rapier3d-compat": "^0.19.3",
         "three": "^0.170.0"
       },
       "devDependencies": {
@@ -17,6 +18,12 @@
         "typescript": "^5.3.0",
         "vite": "^6.0.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.19.3.tgz",
+      "integrity": "sha512-mMVdSj1PRTT108s9Swbu2GQOmHbn8kbJANRV5xfczL3s0T4vkgZAuoMRgvBzQcHanpKusbC0ZJj6z3mC3aj3vg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dimforge/rapier3d-compat": "^0.19.3",
     "three": "^0.170.0"
   },
   "devDependencies": {

--- a/src/Game.js
+++ b/src/Game.js
@@ -10,6 +10,7 @@ import { UnderwaterEffect } from './shaders/UnderwaterEffect.js';
 import { PreloadCoordinator } from './PreloadCoordinator.js';
 import { AbyssEncounter } from './encounters/AbyssEncounter.js';
 import { qualityManager } from './QualityManager.js';
+import { PhysicsWorld } from './physics/PhysicsWorld.js';
 
 export class Game {
   constructor() {
@@ -52,6 +53,7 @@ export class Game {
     this.audio = new AudioManager();
     this.underwaterEffect = new UnderwaterEffect(this.renderer, this.scene, this.camera);
     this.abyssEncounter = new AbyssEncounter();
+    this.physicsWorld = null; // initialized async in _primeAndEnterGameplay
 
     // Detect high-end GPU for potential ultra tier auto-select
     qualityManager.detectGPU(this.renderer);
@@ -327,6 +329,12 @@ export class Game {
     this._descentActive = true;
     this._updateDescentProgress();
 
+    // Initialize Rapier WASM physics before terrain/player use it
+    this.physicsWorld = new PhysicsWorld();
+    await this.physicsWorld.init();
+    this.terrain.setPhysicsWorld(this.physicsWorld);
+    this.player.setPhysicsWorld(this.physicsWorld);
+
     const primeSummary = await this.preload.primeStartBaseline({
       onProgress: () => this._updateDescentProgress(),
     });
@@ -407,6 +415,11 @@ export class Game {
     const depth = Math.max(0, -this.player.position.y);
     this.depth = depth;
     this.player.depth = depth;
+
+    // Step physics before player update so collisions are current
+    if (this.physicsWorld) {
+      this.physicsWorld.step(dt);
+    }
 
     // Update systems
     this.player.update(dt);

--- a/src/environment/Terrain.js
+++ b/src/environment/Terrain.js
@@ -12,6 +12,7 @@ export class Terrain {
     this.lastChunkZ = null;
     this.viewDistance = qualityManager.getSettings().terrainViewDistance;
     this._pendingChunks = []; // queue for staggered generation
+    this._physicsWorld = null;
 
     window.addEventListener('qualitychange', (e) => {
       this.viewDistance = e.detail.settings.terrainViewDistance;
@@ -28,6 +29,14 @@ export class Terrain {
       metalness: 0.05,
       flatShading: true,
     });
+  }
+
+  /**
+   * Attach physics world for collision generation.
+   * @param {import('../physics/PhysicsWorld.js').PhysicsWorld} physicsWorld
+   */
+  setPhysicsWorld(physicsWorld) {
+    this._physicsWorld = physicsWorld;
   }
 
   _getChunkKey(cx, cz) {
@@ -106,7 +115,36 @@ export class Terrain {
     // Add rocks
     this._addRocks(mesh, offsetX, offsetZ, size);
 
+    // Create physics trimesh collider for this chunk
+    if (this._physicsWorld) {
+      this._createChunkCollider(mesh, positions, geo.index, offsetX, offsetZ);
+    }
+
     return mesh;
+  }
+
+  /**
+   * Build a trimesh collider from chunk geometry.
+   */
+  _createChunkCollider(mesh, positions, geoIndex, offsetX, offsetZ) {
+    // Build world-space vertices
+    const vertCount = positions.length / 3;
+    const worldVerts = new Float32Array(positions.length);
+    for (let i = 0; i < vertCount; i++) {
+      worldVerts[i * 3] = positions[i * 3] + offsetX;
+      worldVerts[i * 3 + 1] = positions[i * 3 + 1];
+      worldVerts[i * 3 + 2] = positions[i * 3 + 2] + offsetZ;
+    }
+
+    // Extract indices from the geometry index (PlaneGeometry always has an index)
+    const srcIndex = geoIndex.array;
+    const indices = new Uint32Array(srcIndex.length);
+    for (let i = 0; i < srcIndex.length; i++) {
+      indices[i] = srcIndex[i];
+    }
+
+    const handle = this._physicsWorld.createTrimeshCollider(worldVerts, indices);
+    mesh.userData.physicsColliderHandles = [handle];
   }
 
   _addRocks(parent, offsetX, offsetZ, size) {
@@ -134,6 +172,28 @@ export class Terrain {
 
     instancedRocks.instanceMatrix.needsUpdate = true;
     parent.add(instancedRocks);
+
+    // Create physics sphere colliders for each rock
+    if (this._physicsWorld) {
+      const handles = parent.userData.physicsColliderHandles || [];
+      const mat4 = new THREE.Matrix4();
+      const pos = new THREE.Vector3();
+      const scl = new THREE.Vector3();
+      const quat = new THREE.Quaternion();
+      for (let i = 0; i < count; i++) {
+        instancedRocks.getMatrixAt(i, mat4);
+        mat4.decompose(pos, quat, scl);
+        // World-space position: rock local pos + chunk offset
+        const wx = pos.x + offsetX;
+        const wy = pos.y;
+        const wz = pos.z + offsetZ;
+        // Use average scale as sphere radius
+        const radius = (scl.x + scl.y + scl.z) / 3;
+        const handle = this._physicsWorld.createSphereCollider(wx, wy, wz, radius);
+        handles.push(handle);
+      }
+      parent.userData.physicsColliderHandles = handles;
+    }
   }
 
   _rebuildPendingAround(cx, cz) {
@@ -147,6 +207,12 @@ export class Terrain {
     // Remove distant chunks
     for (const [key, mesh] of this.chunks) {
       if (!needed.has(key)) {
+        // Remove physics colliders
+        if (this._physicsWorld && mesh.userData.physicsColliderHandles) {
+          for (const handle of mesh.userData.physicsColliderHandles) {
+            this._physicsWorld.removeCollider(handle);
+          }
+        }
         this.scene.remove(mesh);
         mesh.geometry.dispose();
         mesh.material.dispose();

--- a/src/physics/PhysicsWorld.js
+++ b/src/physics/PhysicsWorld.js
@@ -1,0 +1,131 @@
+import RAPIER from '@dimforge/rapier3d-compat';
+
+export class PhysicsWorld {
+  constructor() {
+    this.world = null;
+    this.characterController = null;
+    this._colliders = new Map(); // handle → collider
+    this._bodies = new Map();   // handle → rigidBody
+  }
+
+  async init() {
+    await RAPIER.init();
+    // Zero gravity — the game handles movement via velocity + drag
+    this.world = new RAPIER.World({ x: 0, y: 0, z: 0 });
+
+    // KinematicCharacterController with 0.01 skin width
+    this.characterController = this.world.createCharacterController(0.01);
+    // Slide along surfaces instead of hard stops
+    this.characterController.setSlideEnabled(true);
+    // Max slope angle (60 degrees) before the controller can't climb
+    this.characterController.setMaxSlopeClimbAngle((60 * Math.PI) / 180);
+    // Auto-step for small ledges
+    this.characterController.enableAutostep(0.5, 0.2, true);
+    // Snap to ground within a small distance to prevent floating
+    this.characterController.enableSnapToGround(0.3);
+  }
+
+  step(dt) {
+    if (!this.world) return;
+    this.world.timestep = dt;
+    this.world.step();
+  }
+
+  /**
+   * Create a trimesh collider for terrain geometry.
+   * @param {Float32Array} vertices - flattened xyz vertex positions (world-space)
+   * @param {Uint32Array} indices - triangle index buffer
+   * @returns {number} collider handle for later removal
+   */
+  createTrimeshCollider(vertices, indices) {
+    const bodyDesc = RAPIER.RigidBodyDesc.fixed();
+    const body = this.world.createRigidBody(bodyDesc);
+
+    const colliderDesc = RAPIER.ColliderDesc.trimesh(vertices, indices);
+    const collider = this.world.createCollider(colliderDesc, body);
+
+    const handle = collider.handle;
+    this._colliders.set(handle, collider);
+    this._bodies.set(handle, body);
+    return handle;
+  }
+
+  /**
+   * Create a sphere collider for a rock at a given position.
+   * @param {number} x
+   * @param {number} y
+   * @param {number} z
+   * @param {number} radius
+   * @returns {number} collider handle
+   */
+  createSphereCollider(x, y, z, radius) {
+    const bodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(x, y, z);
+    const body = this.world.createRigidBody(bodyDesc);
+
+    const colliderDesc = RAPIER.ColliderDesc.ball(radius);
+    const collider = this.world.createCollider(colliderDesc, body);
+
+    const handle = collider.handle;
+    this._colliders.set(handle, collider);
+    this._bodies.set(handle, body);
+    return handle;
+  }
+
+  /**
+   * Create a capsule collider for the player (kinematic position-based).
+   * @param {number} x
+   * @param {number} y
+   * @param {number} z
+   * @param {number} halfHeight
+   * @param {number} radius
+   * @returns {{ collider: object, body: object }}
+   */
+  createPlayerCollider(x, y, z, halfHeight, radius) {
+    const bodyDesc = RAPIER.RigidBodyDesc.kinematicPositionBased()
+      .setTranslation(x, y, z);
+    const body = this.world.createRigidBody(bodyDesc);
+
+    const colliderDesc = RAPIER.ColliderDesc.capsule(halfHeight, radius);
+    const collider = this.world.createCollider(colliderDesc, body);
+
+    return { collider, body };
+  }
+
+  /**
+   * Compute corrected movement for the character controller.
+   * @param {object} collider - the player's collider
+   * @param {{ x: number, y: number, z: number }} desiredMovement
+   * @returns {{ x: number, y: number, z: number }} corrected movement
+   */
+  computeMovement(collider, desiredMovement) {
+    this.characterController.computeColliderMovement(collider, desiredMovement);
+    const corrected = this.characterController.computedMovement();
+    return { x: corrected.x, y: corrected.y, z: corrected.z };
+  }
+
+  /**
+   * Remove a collider and its rigid body by handle.
+   * @param {number} handle
+   */
+  removeCollider(handle) {
+    const collider = this._colliders.get(handle);
+    const body = this._bodies.get(handle);
+    if (collider) {
+      this.world.removeCollider(collider, true);
+      this._colliders.delete(handle);
+    }
+    if (body) {
+      this.world.removeRigidBody(body);
+      this._bodies.delete(handle);
+    }
+  }
+
+  dispose() {
+    if (this.world) {
+      this.world.free();
+      this.world = null;
+    }
+    this._colliders.clear();
+    this._bodies.clear();
+  }
+}

--- a/src/player/Player.js
+++ b/src/player/Player.js
@@ -120,6 +120,11 @@ export class Player {
     this.bobTime = 0;
     this.bobAmount = 0.03;
 
+    // Physics (set later via setPhysicsWorld)
+    this._physicsWorld = null;
+    this._physicsCollider = null;
+    this._physicsBody = null;
+
     this._setupControls();
   }
 
@@ -239,11 +244,30 @@ export class Player {
     document.exitPointerLock();
   }
 
+  /**
+   * Attach physics world and create the player's capsule collider.
+   * @param {import('../physics/PhysicsWorld.js').PhysicsWorld} physicsWorld
+   */
+  setPhysicsWorld(physicsWorld) {
+    this._physicsWorld = physicsWorld;
+    const { collider, body } = physicsWorld.createPlayerCollider(
+      this.position.x, this.position.y, this.position.z,
+      1,  // half-height
+      2   // radius
+    );
+    this._physicsCollider = collider;
+    this._physicsBody = body;
+  }
+
   reset() {
     this.position.set(0, -5, 0);
     this.velocity.set(0, 0, 0);
     this.euler.set(0, 0, 0);
     this.camera.quaternion.setFromEuler(this.euler);
+    // Sync physics body to reset position
+    if (this._physicsBody) {
+      this._physicsBody.setNextKinematicTranslation({ x: 0, y: -5, z: 0 });
+    }
   }
 
   update(dt) {
@@ -268,9 +292,43 @@ export class Player {
 
     this.velocity.add(this._accel.multiplyScalar(dt));
     this.velocity.multiplyScalar(1 - this.dampening * dt);
-    this.position.addScaledVector(this.velocity, dt);
 
-    // Keep player below water surface
+    // Compute desired movement delta
+    const dx = this.velocity.x * dt;
+    const dy = this.velocity.y * dt;
+    const dz = this.velocity.z * dt;
+
+    // Use physics character controller if available
+    if (this._physicsWorld && this._physicsCollider && this._physicsBody) {
+      const corrected = this._physicsWorld.computeMovement(
+        this._physicsCollider,
+        { x: dx, y: dy, z: dz }
+      );
+      this.position.x += corrected.x;
+      this.position.y += corrected.y;
+      this.position.z += corrected.z;
+
+      // If movement was blocked on an axis, zero that velocity component
+      // to prevent velocity buildup against walls
+      const tolerance = 0.001;
+      if (Math.abs(dx) > tolerance && Math.abs(corrected.x) < tolerance) this.velocity.x = 0;
+      if (Math.abs(dy) > tolerance && Math.abs(corrected.y) < tolerance) this.velocity.y = 0;
+      if (Math.abs(dz) > tolerance && Math.abs(corrected.z) < tolerance) this.velocity.z = 0;
+
+      // Sync kinematic body to new position
+      this._physicsBody.setNextKinematicTranslation({
+        x: this.position.x,
+        y: this.position.y,
+        z: this.position.z,
+      });
+    } else {
+      // Fallback: no physics, apply raw movement
+      this.position.x += dx;
+      this.position.y += dy;
+      this.position.z += dz;
+    }
+
+    // Keep player below water surface (post-physics constraint)
     if (this.position.y > -1) {
       this.position.y = -1;
       this.velocity.y = 0;


### PR DESCRIPTION
## Summary

Implements collision detection using Rapier3D (`@dimforge/rapier3d-compat`) so the submarine can't pass through terrain or rocks.

Fixes #87

## Changes

### New file: `src/physics/PhysicsWorld.js`
- Wraps Rapier world creation with zero gravity (existing velocity+drag system handles movement)
- Provides `createTrimeshCollider()` for terrain chunks
- Provides `createSphereCollider()` for rocks
- Provides `createPlayerCollider()` for a capsule-shaped kinematic body
- `computeMovement()` uses KinematicCharacterController for sliding collision response
- `removeCollider()` for cleanup when chunks are unloaded

### Modified: `src/Game.js`
- Imports and initializes PhysicsWorld (async WASM init) in `_primeAndEnterGameplay()` before terrain loads
- Passes physics world to Terrain and Player via `setPhysicsWorld()`
- Steps physics each frame in `_animate()` before `player.update(dt)`

### Modified: `src/player/Player.js`
- `setPhysicsWorld()` creates a capsule collider (radius=2, half-height=1)
- `update(dt)` computes desired movement, passes through `computeMovement()` for collision-corrected delta
- Zeroes velocity on blocked axes to prevent buildup against walls
- Syncs kinematic body position each frame
- Y=-1 water surface constraint preserved as post-physics clamp
- Graceful fallback: works without physics (raw movement) if not initialized

### Modified: `src/environment/Terrain.js`
- `setPhysicsWorld()` stores physics reference
- `_createChunk()` builds a trimesh collider from chunk geometry vertices+indices in world space
- `_addRocks()` creates sphere colliders per rock instance (radius = average scale)
- `_rebuildPendingAround()` removes physics colliders when chunks are unloaded

### Modified: `package.json`
- Added `@dimforge/rapier3d-compat` dependency

## Acceptance Criteria Checklist
- [x] Submarine cannot pass through terrain (trimesh colliders)
- [x] Submarine cannot pass through rocks (sphere colliders)
- [x] Submarine slides along surfaces naturally (KinematicCharacterController with autostep + slope limits)
- [x] No tunneling at normal gameplay speeds (character controller handles this)
- [x] Water surface constraint (Y = -1) still works (post-physics clamp)
- [x] `npm run build` succeeds