### PR TITLE
fix: drive autoplay descent

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -656,7 +656,10 @@ export class Game {
 
   _updateAutoplayDrive(depth) {
     if (!this.autoplay) {
-      this.player.clearAutoplayInput();
+      const autoplayInput = this.player.autoplayInput;
+      if (autoplayInput.forward !== 0 || autoplayInput.right !== 0 || autoplayInput.vertical !== 0) {
+        this.player.clearAutoplayInput();
+      }
       return;
     }
 

--- a/src/player/Player.js
+++ b/src/player/Player.js
@@ -132,14 +132,20 @@ export class Player {
     }
   }
 
-  setAutoplayInput({ forward = 0, right = 0, vertical = 0 } = {}) {
+  setAutoplayInput(input) {
+    const forward = input?.forward ?? 0;
+    const right = input?.right ?? 0;
+    const vertical = input?.vertical ?? 0;
+
     this.autoplayInput.forward = THREE.MathUtils.clamp(forward, -1, 1);
     this.autoplayInput.right = THREE.MathUtils.clamp(right, -1, 1);
     this.autoplayInput.vertical = THREE.MathUtils.clamp(vertical, -1, 1);
   }
 
   clearAutoplayInput() {
-    this.setAutoplayInput();
+    this.autoplayInput.forward = 0;
+    this.autoplayInput.right = 0;
+    this.autoplayInput.vertical = 0;
   }
 
   update(dt) {


### PR DESCRIPTION
## Summary
- add a dedicated autoplay input channel in the player movement stack
- drive continuous downward movement with a light forward bias only when `?autoplay` is active
- keep manual controls, manual start flow, and pointer-lock bypass behavior intact

## Validation
- `npm run build`