### PR TITLE
fix: offload terrain and flora chunk payload generation to worker

### DIFF
--- a/src/environment/Flora.js
+++ b/src/environment/Flora.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { noise2D } from '../utils/noise.js';
 import { qualityManager } from '../QualityManager.js';
 
 export class Flora {
@@ -13,6 +12,31 @@ export class Flora {
     this.kelps = [];
     this._pendingChunks = []; // queue for staggered generation
     this._floraDensityScale = qualityManager.getSettings().floraDensityScale;
+    this._neededChunkKeys = new Set();
+    this._readyPayloads = [];
+    this._requestSeq = 0;
+    this._inFlightById = new Map();
+    this._inFlightByKey = new Map();
+    this._maxInFlight = 2;
+    this._chunkWorker = new Worker(new URL('./chunkPayloadWorker.js', import.meta.url), { type: 'module' });
+    this._chunkWorker.onmessage = (event) => {
+      const data = event.data;
+      if (!data || data.type !== 'floraPayload') return;
+
+      const request = this._inFlightById.get(data.requestId);
+      if (!request) return;
+
+      this._inFlightById.delete(data.requestId);
+      if (this._inFlightByKey.get(request.key) === data.requestId) {
+        this._inFlightByKey.delete(request.key);
+      }
+
+      if (request.cancelled || !this._neededChunkKeys.has(request.key) || this.groups.has(request.key)) {
+        return;
+      }
+
+      this._readyPayloads.push({ key: request.key, cx: data.cx, cz: data.cz, payload: data.payload });
+    };
 
     // Shared geometry/materials for instanced bio-orbs
     this._orbGeo = new THREE.SphereGeometry(1, 8, 8);
@@ -47,61 +71,58 @@ export class Flora {
 
   _getChunkKey(cx, cz) { return `${cx},${cz}`; }
 
-  _createFloraChunk(cx, cz) {
+  _cancelInFlightRequest(requestId) {
+    const req = this._inFlightById.get(requestId);
+    if (!req) return;
+
+    req.cancelled = true;
+    this._inFlightById.delete(requestId);
+    if (this._inFlightByKey.get(req.key) === requestId) {
+      this._inFlightByKey.delete(req.key);
+    }
+    this._chunkWorker.postMessage({ type: 'cancel', requestId });
+  }
+
+  _requestChunkPayload(key, cx, cz) {
+    if (this._inFlightByKey.has(key)) return false;
+    const requestId = ++this._requestSeq;
+    this._inFlightById.set(requestId, { key, cancelled: false });
+    this._inFlightByKey.set(key, requestId);
+    this._chunkWorker.postMessage({
+      type: 'generateFlora',
+      requestId,
+      key,
+      cx,
+      cz,
+      chunkSize: this.chunkSize,
+      floraDensityScale: this._floraDensityScale,
+    });
+    return true;
+  }
+
+  _createFloraChunkFromPayload(cx, cz, payload) {
     const group = new THREE.Group();
-    const size = this.chunkSize;
-    const offsetX = cx * size;
-    const offsetZ = cz * size;
+    const offsetX = cx * this.chunkSize;
+    const offsetZ = cz * this.chunkSize;
 
-    // Collectors for instanced geometry
-    const orbData = [];     // { x, y, z, size, color }
-    const tubeData = [];    // { x, y, z, height, rx, rz }
-    const tipData = [];     // { x, y, z }
+    for (const kelp of payload.kelps) {
+      this._addKelpFromData(group, kelp);
+    }
 
-    // Use noise to determine flora placement
-    const floraCount = Math.round((12 + Math.floor(Math.random() * 10)) * this._floraDensityScale);
-    let lightsInChunk = 0;
-
-    for (let i = 0; i < floraCount; i++) {
-      const fx = (Math.random() - 0.5) * size * 0.9;
-      const fz = (Math.random() - 0.5) * size * 0.9;
-      const worldX = fx + offsetX;
-      const worldZ = fz + offsetZ;
-
-      // Estimate terrain height at this position
-      const terrainVal = noise2D(worldX * 0.003, worldZ * 0.003) * 40;
-      const baseDepth = -80 - Math.abs(noise2D(worldX * 0.001, worldZ * 0.001)) * 400;
-      const groundY = baseDepth + terrainVal;
-      const depth = -groundY;
-
-      const type = Math.random();
-
-      if (depth < 150 && type < 0.4) {
-        // Kelp strands
-        this._addKelp(group, fx, groundY, fz);
-      } else if (depth < 300 && type < 0.6) {
-        // Coral formations
-        this._addCoral(group, fx, groundY, fz, depth);
-      } else if (depth > 100 && type < 0.8) {
-        // Bioluminescent orbs — collect for instanced batching
-        lightsInChunk = this._collectBioOrb(group, orbData, fx, groundY, fz, depth, lightsInChunk);
-      } else if (depth > 200) {
-        // Deep sea tube worms — collect for instanced batching
-        this._collectTubeWorms(tubeData, tipData, fx, groundY, fz);
-      }
+    for (const coral of payload.corals) {
+      this._addCoralFromData(group, coral);
     }
 
     // Batch bio-orbs into InstancedMesh
-    if (orbData.length > 0) {
-      const orbColors = [0x00ffaa, 0x00aaff, 0x8844ff, 0xff00aa, 0x44ffaa];
-      const instancedOrbs = new THREE.InstancedMesh(this._orbGeo, this._orbMat, orbData.length);
+    if (payload.orbs.length > 0) {
+      const instancedOrbs = new THREE.InstancedMesh(this._orbGeo, this._orbMat, payload.orbs.length);
       instancedOrbs.instanceColor = new THREE.InstancedBufferAttribute(
-        new Float32Array(orbData.length * 3), 3
+        new Float32Array(payload.orbs.length * 3), 3
       );
       const dummy = new THREE.Object3D();
       const tmpColor = new THREE.Color();
-      for (let i = 0; i < orbData.length; i++) {
-        const d = orbData[i];
+      for (let i = 0; i < payload.orbs.length; i++) {
+        const d = payload.orbs[i];
         dummy.position.set(d.x, d.y, d.z);
         dummy.scale.setScalar(d.size);
         dummy.updateMatrix();
@@ -114,12 +135,18 @@ export class Flora {
       group.add(instancedOrbs);
     }
 
+    for (const lightData of payload.orbLights) {
+      const light = new THREE.PointLight(lightData.color, lightData.intensity, lightData.distance);
+      light.position.set(lightData.x, lightData.y, lightData.z);
+      group.add(light);
+    }
+
     // Batch tube worm cylinders into InstancedMesh
-    if (tubeData.length > 0) {
-      const instancedTubes = new THREE.InstancedMesh(this._tubeGeo, this._tubeMat, tubeData.length);
+    if (payload.tubes.length > 0) {
+      const instancedTubes = new THREE.InstancedMesh(this._tubeGeo, this._tubeMat, payload.tubes.length);
       const dummy = new THREE.Object3D();
-      for (let i = 0; i < tubeData.length; i++) {
-        const d = tubeData[i];
+      for (let i = 0; i < payload.tubes.length; i++) {
+        const d = payload.tubes[i];
         dummy.position.set(d.x, d.y, d.z);
         dummy.scale.set(1, d.height, 1);
         dummy.rotation.set(d.rx, 0, d.rz);
@@ -131,11 +158,11 @@ export class Flora {
     }
 
     // Batch tube worm tips into InstancedMesh
-    if (tipData.length > 0) {
-      const instancedTips = new THREE.InstancedMesh(this._tipGeo, this._tipMat, tipData.length);
+    if (payload.tubeTips.length > 0) {
+      const instancedTips = new THREE.InstancedMesh(this._tipGeo, this._tipMat, payload.tubeTips.length);
       const dummy = new THREE.Object3D();
-      for (let i = 0; i < tipData.length; i++) {
-        const d = tipData[i];
+      for (let i = 0; i < payload.tubeTips.length; i++) {
+        const d = payload.tubeTips[i];
         dummy.position.set(d.x, d.y, d.z);
         dummy.scale.setScalar(1);
         dummy.updateMatrix();
@@ -149,20 +176,18 @@ export class Flora {
     return group;
   }
 
-  _addKelp(parent, x, y, z) {
-    const segments = 8 + Math.floor(Math.random() * 6);
-    const height = 6 + Math.random() * 10;
-    const segHeight = height / segments;
+  _addKelpFromData(parent, kelpData) {
+    const segHeight = kelpData.height / kelpData.segments;
 
     const points = [];
-    for (let i = 0; i <= segments; i++) {
+    for (let i = 0; i <= kelpData.segments; i++) {
       points.push(new THREE.Vector3(0, i * segHeight, 0));
     }
 
     const curve = new THREE.CatmullRomCurve3(points);
-    const geo = new THREE.TubeGeometry(curve, segments, 0.08 + Math.random() * 0.05, 4, false);
+    const geo = new THREE.TubeGeometry(curve, kelpData.segments, kelpData.radius, 4, false);
     const mat = new THREE.MeshStandardMaterial({
-      color: new THREE.Color(0.1, 0.3 + Math.random() * 0.2, 0.05),
+      color: new THREE.Color(0.1, kelpData.green, 0.05),
       roughness: 0.8,
       transparent: true,
       opacity: 0.8,
@@ -170,91 +195,83 @@ export class Flora {
     });
 
     const kelp = new THREE.Mesh(geo, mat);
-    kelp.position.set(x, y, z);
+    kelp.position.set(kelpData.x, kelpData.y, kelpData.z);
     parent.add(kelp);
 
-    // Store for animation
-    this.kelps.push({ mesh: kelp, curve, segHeight, segments, phase: Math.random() * Math.PI * 2 });
+    this.kelps.push({
+      mesh: kelp,
+      curve,
+      segHeight,
+      segments: kelpData.segments,
+      phase: kelpData.phase,
+    });
 
-    // Kelp leaves
-    for (let i = 2; i < segments; i += 2) {
+    for (const leafData of kelpData.leafRotations) {
       const leafGeo = new THREE.PlaneGeometry(0.8, 0.3);
       const leaf = new THREE.Mesh(leafGeo, mat);
-      leaf.position.set(x + 0.3, y + i * segHeight, z);
-      leaf.rotation.y = Math.random() * Math.PI;
+      leaf.position.set(kelpData.x + 0.3, kelpData.y + leafData.y, kelpData.z);
+      leaf.rotation.y = leafData.ry;
       leaf.rotation.z = Math.PI / 4;
       parent.add(leaf);
     }
   }
 
-  _addCoral(parent, x, y, z, depth) {
-    const colorChoices = depth < 100
-      ? [0xff6644, 0xff44aa, 0xffaa33, 0xff8866]  // Shallow: vibrant
-      : [0x664455, 0x554466, 0x445566, 0x556644];  // Deep: muted
+  _addCoralFromData(parent, coralData) {
+    const emissive = coralData.emissiveFactor > 0
+      ? new THREE.Color(coralData.color).multiplyScalar(coralData.emissiveFactor)
+      : new THREE.Color(0);
+    const mat = new THREE.MeshStandardMaterial({
+      color: coralData.color,
+      roughness: 0.7,
+      emissive,
+    });
 
-    const color = colorChoices[Math.floor(Math.random() * colorChoices.length)];
-
-    // Branching coral structure
-    const create = (px, py, pz, size, depth_r) => {
-      if (depth_r > 3 || size < 0.15) return;
-      const geo = new THREE.CylinderGeometry(size * 0.6, size, size * 3, 5);
-      const mat = new THREE.MeshStandardMaterial({
-        color,
-        roughness: 0.7,
-        emissive: depth > 200 ? new THREE.Color(color).multiplyScalar(0.1) : new THREE.Color(0),
-      });
+    for (const branchData of coralData.branches) {
+      const geo = new THREE.CylinderGeometry(branchData.size * 0.6, branchData.size, branchData.size * 3, 5);
       const branch = new THREE.Mesh(geo, mat);
-      branch.position.set(px, py + size * 1.5, pz);
-      branch.rotation.x = (Math.random() - 0.5) * 0.5;
-      branch.rotation.z = (Math.random() - 0.5) * 0.5;
+      branch.position.set(branchData.x, branchData.y, branchData.z);
+      branch.rotation.x = branchData.rx;
+      branch.rotation.z = branchData.rz;
       parent.add(branch);
+    }
+  }
 
-      const branches = 2 + Math.floor(Math.random() * 2);
-      for (let i = 0; i < branches; i++) {
-        const angle = (i / branches) * Math.PI * 2 + Math.random() * 0.5;
-        create(
-          px + Math.cos(angle) * size,
-          py + size * 3,
-          pz + Math.sin(angle) * size,
-          size * 0.65,
-          depth_r + 1
-        );
+  _applyReadyPayloads(maxCount, cancelToken) {
+    let applied = 0;
+    while (this._readyPayloads.length > 0 && applied < maxCount) {
+      if (cancelToken?.cancelled) break;
+      const next = this._readyPayloads.shift();
+      if (!next) break;
+
+      const { key, cx, cz, payload } = next;
+      if (!this._neededChunkKeys.has(key) || this.groups.has(key)) {
+        continue;
       }
-    };
 
-    create(x, y, z, 0.4 + Math.random() * 0.4, 0);
+      const chunk = this._createFloraChunkFromPayload(cx, cz, payload);
+      this.scene.add(chunk);
+      this.groups.set(key, chunk);
+      applied++;
+    }
+    return applied;
   }
 
-  _collectBioOrb(parent, orbData, x, y, z, depth, lightsInChunk) {
-    const colors = [0x00ffaa, 0x00aaff, 0x8844ff, 0xff00aa, 0x44ffaa];
-    const color = colors[Math.floor(Math.random() * colors.length)];
-    const size = 0.1 + Math.random() * 0.3;
+  _requestPendingChunks(maxCount, cancelToken) {
+    let requested = 0;
+    while (this._pendingChunks.length > 0 && requested < maxCount) {
+      if (cancelToken?.cancelled) break;
+      if (this._inFlightByKey.size >= this._maxInFlight) break;
 
-    orbData.push({ x, y: y + 1 + Math.random() * 5, z, size, color });
+      const { key, x, z } = this._pendingChunks.shift();
+      if (this.groups.has(key) || this._inFlightByKey.has(key) || !this._neededChunkKeys.has(key)) {
+        continue;
+      }
 
-    // Point light for glow — capped at 2 per chunk to reduce draw calls
-    if (lightsInChunk < 2 && Math.random() < 0.1) {
-      const light = new THREE.PointLight(color, 0.8, 25);
-      light.position.set(x, y + 1 + Math.random() * 5, z);
-      parent.add(light);
-      lightsInChunk++;
+      if (this._requestChunkPayload(key, x, z)) {
+        requested++;
+      }
     }
-
-    return lightsInChunk;
-  }
-
-  _collectTubeWorms(tubeData, tipData, x, y, z) {
-    const count = 3 + Math.floor(Math.random() * 5);
-    for (let i = 0; i < count; i++) {
-      const height = 1 + Math.random() * 3;
-      const tx = x + (Math.random() - 0.5) * 0.5;
-      const tz = z + (Math.random() - 0.5) * 0.5;
-      const rx = (Math.random() - 0.5) * 0.15;
-      const rz = (Math.random() - 0.5) * 0.15;
-
-      tubeData.push({ x: tx, y: y + height / 2, z: tz, height, rx, rz });
-      tipData.push({ x: tx, y: y + height, z: tz });
-    }
+    return requested;
   }
 
   _disposeGroup(group) {
@@ -279,6 +296,14 @@ export class Flora {
         needed.add(this._getChunkKey(cx + dx, cz + dz));
       }
     }
+    this._neededChunkKeys = needed;
+
+    for (const [requestId, req] of this._inFlightById) {
+      if (!needed.has(req.key)) {
+        this._cancelInFlightRequest(requestId);
+      }
+    }
+    this._readyPayloads = this._readyPayloads.filter(entry => needed.has(entry.key));
 
     for (const [key, group] of this.groups) {
       if (!needed.has(key)) {
@@ -307,22 +332,29 @@ export class Flora {
 
   preloadDrain(maxCount, cancelToken) {
     if (maxCount <= 0) return 0;
-    let built = 0;
-    while (this._pendingChunks.length > 0 && built < maxCount) {
+    let progress = 0;
+    while (progress < maxCount) {
       if (cancelToken?.cancelled) break;
-      const { key, x, z } = this._pendingChunks.shift();
-      if (!this.groups.has(key)) {
-        const chunk = this._createFloraChunk(x, z);
-        this.scene.add(chunk);
-        this.groups.set(key, chunk);
-        built++;
+
+      const applied = this._applyReadyPayloads(1, cancelToken);
+      if (applied > 0) {
+        progress += applied;
+        continue;
       }
+
+      const requested = this._requestPendingChunks(1, cancelToken);
+      if (requested > 0) {
+        progress += requested;
+        continue;
+      }
+
+      break;
     }
-    return built;
+    return progress;
   }
 
   getPendingCount() {
-    return this._pendingChunks.length;
+    return this._pendingChunks.length + this._inFlightById.size + this._readyPayloads.length;
   }
 
   getChunkCount() {
@@ -332,15 +364,9 @@ export class Flora {
   update(dt, playerPos) {
     this.time += dt;
 
-    // Build at most 1 pending flora chunk per frame to avoid frame spikes
-    if (this._pendingChunks.length > 0) {
-      const { key, x, z } = this._pendingChunks.shift();
-      if (!this.groups.has(key)) {
-        const chunk = this._createFloraChunk(x, z);
-        this.scene.add(chunk);
-        this.groups.set(key, chunk);
-      }
-    }
+    // Build/apply at most 1 payload per frame and request at most 1 new chunk
+    this._applyReadyPayloads(1);
+    this._requestPendingChunks(1);
 
     // Chunk management
     const cx = Math.round(playerPos.x / this.chunkSize);

--- a/src/environment/Terrain.js
+++ b/src/environment/Terrain.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { fbm2D, noise2D } from '../utils/noise.js';
 import { qualityManager } from '../QualityManager.js';
 
 export class Terrain {
@@ -13,6 +12,31 @@ export class Terrain {
     this.viewDistance = qualityManager.getSettings().terrainViewDistance;
     this._pendingChunks = []; // queue for staggered generation
     this._physicsWorld = null;
+    this._neededChunkKeys = new Set();
+    this._readyPayloads = [];
+    this._requestSeq = 0;
+    this._inFlightById = new Map();
+    this._inFlightByKey = new Map();
+    this._maxInFlight = 2;
+    this._chunkWorker = new Worker(new URL('./chunkPayloadWorker.js', import.meta.url), { type: 'module' });
+    this._chunkWorker.onmessage = (event) => {
+      const data = event.data;
+      if (!data || data.type !== 'terrainPayload') return;
+
+      const request = this._inFlightById.get(data.requestId);
+      if (!request) return;
+
+      this._inFlightById.delete(data.requestId);
+      if (this._inFlightByKey.get(request.key) === data.requestId) {
+        this._inFlightByKey.delete(request.key);
+      }
+
+      if (request.cancelled || !this._neededChunkKeys.has(request.key) || this.chunks.has(request.key)) {
+        return;
+      }
+
+      this._readyPayloads.push({ key: request.key, cx: data.cx, cz: data.cz, payload: data.payload });
+    };
 
     window.addEventListener('qualitychange', (e) => {
       this.viewDistance = e.detail.settings.terrainViewDistance;
@@ -43,129 +67,57 @@ export class Terrain {
     return `${cx},${cz}`;
   }
 
-  _getTerrainHeight(x, z) {
-    // Multi-layered terrain
-    let h = fbm2D(x * 0.003, z * 0.003, 6) * 40;
-    // Add ridges
-    h += Math.abs(noise2D(x * 0.01, z * 0.01)) * 15;
-    // Deep trenches
-    const trench = noise2D(x * 0.005 + 100, z * 0.005 + 100);
-    if (trench > 0.3) {
-      h -= (trench - 0.3) * 100;
+  _cancelInFlightRequest(requestId) {
+    const req = this._inFlightById.get(requestId);
+    if (!req) return;
+
+    req.cancelled = true;
+    this._inFlightById.delete(requestId);
+    if (this._inFlightByKey.get(req.key) === requestId) {
+      this._inFlightByKey.delete(req.key);
     }
-    return h;
+    this._chunkWorker.postMessage({ type: 'cancel', requestId });
   }
 
-  _createChunk(cx, cz) {
-    const size = this.chunkSize;
-    const res = this.resolution;
-    const geo = new THREE.PlaneGeometry(size, size, res, res);
-    geo.rotateX(-Math.PI / 2);
-
-    const positions = geo.attributes.position.array;
-    const colors = new Float32Array(positions.length);
-
-    const offsetX = cx * size;
-    const offsetZ = cz * size;
-
-    for (let i = 0; i < positions.length; i += 3) {
-      const worldX = positions[i] + offsetX;
-      const worldZ = positions[i + 2] + offsetZ;
-      const h = this._getTerrainHeight(worldX, worldZ);
-
-      // Terrain depth base: -50 to -800 depending on position
-      const baseDepth = -80 - Math.abs(fbm2D(worldX * 0.001, worldZ * 0.001)) * 600;
-      positions[i + 1] = baseDepth + h;
-
-      // Color based on depth
-      const depth = -positions[i + 1];
-      if (depth < 80) {
-        // Sandy/coral
-        colors[i] = 0.6; colors[i + 1] = 0.5; colors[i + 2] = 0.3;
-      } else if (depth < 200) {
-        // Darker sand/rock
-        colors[i] = 0.3; colors[i + 1] = 0.25; colors[i + 2] = 0.2;
-      } else if (depth < 500) {
-        // Dark rock
-        colors[i] = 0.15; colors[i + 1] = 0.12; colors[i + 2] = 0.15;
-      } else {
-        // Abyss - dark with slight purple
-        colors[i] = 0.08; colors[i + 1] = 0.05; colors[i + 2] = 0.1;
-      }
-
-      // Small color variation
-      const v = noise2D(worldX * 0.1, worldZ * 0.1) * 0.05;
-      colors[i] += v; colors[i + 1] += v; colors[i + 2] += v;
-    }
-
-    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-    geo.computeVertexNormals();
-
-    const mat = new THREE.MeshStandardMaterial({
-      vertexColors: true,
-      roughness: 0.9,
-      metalness: 0.1,
-      flatShading: true,
+  _requestChunkPayload(key, cx, cz) {
+    if (this._inFlightByKey.has(key)) return false;
+    const requestId = ++this._requestSeq;
+    this._inFlightById.set(requestId, { key, cancelled: false });
+    this._inFlightByKey.set(key, requestId);
+    this._chunkWorker.postMessage({
+      type: 'generateTerrain',
+      requestId,
+      key,
+      cx,
+      cz,
+      chunkSize: this.chunkSize,
+      resolution: this.resolution,
     });
-
-    const mesh = new THREE.Mesh(geo, mat);
-    mesh.position.set(offsetX, 0, offsetZ);
-    mesh.receiveShadow = true;
-
-    // Add rocks
-    this._addRocks(mesh, offsetX, offsetZ, size);
-
-    // Create physics trimesh collider for this chunk
-    if (this._physicsWorld) {
-      this._createChunkCollider(mesh, positions, geo.index, offsetX, offsetZ);
-    }
-
-    return mesh;
+    return true;
   }
 
   /**
-   * Build a trimesh collider from chunk geometry.
+   * Build a trimesh collider from worker-generated world-space vertices.
    */
-  _createChunkCollider(mesh, positions, geoIndex, offsetX, offsetZ) {
-    // Build world-space vertices
-    const vertCount = positions.length / 3;
-    const worldVerts = new Float32Array(positions.length);
-    for (let i = 0; i < vertCount; i++) {
-      worldVerts[i * 3] = positions[i * 3] + offsetX;
-      worldVerts[i * 3 + 1] = positions[i * 3 + 1];
-      worldVerts[i * 3 + 2] = positions[i * 3 + 2] + offsetZ;
-    }
-
-    // Extract indices from the geometry index (PlaneGeometry always has an index)
-    const srcIndex = geoIndex.array;
-    const indices = new Uint32Array(srcIndex.length);
-    for (let i = 0; i < srcIndex.length; i++) {
-      indices[i] = srcIndex[i];
-    }
-
-    const handle = this._physicsWorld.createTrimeshCollider(worldVerts, indices);
+  _createChunkCollider(mesh, colliderVertices, indices) {
+    const handle = this._physicsWorld.createTrimeshCollider(colliderVertices, indices);
     mesh.userData.physicsColliderHandles = [handle];
   }
 
-  _addRocks(parent, offsetX, offsetZ, size) {
-    const count = 8 + Math.floor(Math.random() * 8);
+  _addRocksFromPayload(parent, payload) {
+    const count = payload.rockTransforms.length / 9;
+    if (count <= 0) return;
+
     const dummy = new THREE.Object3D();
     const instancedRocks = new THREE.InstancedMesh(this._rockGeo, this._rockMat, count);
     instancedRocks.castShadow = true;
     instancedRocks.receiveShadow = true;
 
     for (let i = 0; i < count; i++) {
-      const rx = (Math.random() - 0.5) * size * 0.8;
-      const rz = (Math.random() - 0.5) * size * 0.8;
-      const worldX = rx + offsetX;
-      const worldZ = rz + offsetZ;
-      const h = this._getTerrainHeight(worldX, worldZ);
-      const baseDepth = -80 - Math.abs(fbm2D(worldX * 0.001, worldZ * 0.001)) * 600;
-
-      const scale = 1 + Math.random() * 4;
-      dummy.position.set(rx, baseDepth + h + scale * 0.3, rz);
-      dummy.scale.set(scale, scale * (0.5 + Math.random() * 0.8), scale);
-      dummy.rotation.set(Math.random(), Math.random(), Math.random());
+      const idx = i * 9;
+      dummy.position.set(payload.rockTransforms[idx], payload.rockTransforms[idx + 1], payload.rockTransforms[idx + 2]);
+      dummy.scale.set(payload.rockTransforms[idx + 3], payload.rockTransforms[idx + 4], payload.rockTransforms[idx + 5]);
+      dummy.rotation.set(payload.rockTransforms[idx + 6], payload.rockTransforms[idx + 7], payload.rockTransforms[idx + 8]);
       dummy.updateMatrix();
       instancedRocks.setMatrixAt(i, dummy.matrix);
     }
@@ -173,27 +125,79 @@ export class Terrain {
     instancedRocks.instanceMatrix.needsUpdate = true;
     parent.add(instancedRocks);
 
-    // Create physics sphere colliders for each rock
+    // Create physics sphere colliders for each rock from worker payload
     if (this._physicsWorld) {
       const handles = parent.userData.physicsColliderHandles || [];
-      const mat4 = new THREE.Matrix4();
-      const pos = new THREE.Vector3();
-      const scl = new THREE.Vector3();
-      const quat = new THREE.Quaternion();
       for (let i = 0; i < count; i++) {
-        instancedRocks.getMatrixAt(i, mat4);
-        mat4.decompose(pos, quat, scl);
-        // World-space position: rock local pos + chunk offset
-        const wx = pos.x + offsetX;
-        const wy = pos.y;
-        const wz = pos.z + offsetZ;
-        // Use average scale as sphere radius
-        const radius = (scl.x + scl.y + scl.z) / 3;
+        const idx = i * 4;
+        const wx = payload.rockColliders[idx];
+        const wy = payload.rockColliders[idx + 1];
+        const wz = payload.rockColliders[idx + 2];
+        const radius = payload.rockColliders[idx + 3];
         const handle = this._physicsWorld.createSphereCollider(wx, wy, wz, radius);
         handles.push(handle);
       }
       parent.userData.physicsColliderHandles = handles;
     }
+  }
+
+  _applyReadyPayloads(maxCount, cancelToken) {
+    let applied = 0;
+    while (this._readyPayloads.length > 0 && applied < maxCount) {
+      if (cancelToken?.cancelled) break;
+      const next = this._readyPayloads.shift();
+      if (!next) break;
+
+      const { key, cx, cz, payload } = next;
+      if (!this._neededChunkKeys.has(key) || this.chunks.has(key)) {
+        continue;
+      }
+
+      const geo = new THREE.BufferGeometry();
+      geo.setAttribute('position', new THREE.BufferAttribute(payload.positions, 3));
+      geo.setAttribute('color', new THREE.BufferAttribute(payload.colors, 3));
+      geo.setIndex(new THREE.BufferAttribute(payload.indices, 1));
+      geo.computeVertexNormals();
+
+      const mat = new THREE.MeshStandardMaterial({
+        vertexColors: true,
+        roughness: 0.9,
+        metalness: 0.1,
+        flatShading: true,
+      });
+
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.set(cx * this.chunkSize, 0, cz * this.chunkSize);
+      mesh.receiveShadow = true;
+
+      this._addRocksFromPayload(mesh, payload);
+      if (this._physicsWorld) {
+        this._createChunkCollider(mesh, payload.colliderVertices, payload.indices);
+      }
+
+      this.scene.add(mesh);
+      this.chunks.set(key, mesh);
+      applied++;
+    }
+    return applied;
+  }
+
+  _requestPendingChunks(maxCount, cancelToken) {
+    let requested = 0;
+    while (this._pendingChunks.length > 0 && requested < maxCount) {
+      if (cancelToken?.cancelled) break;
+      if (this._inFlightByKey.size >= this._maxInFlight) break;
+
+      const { key, x, z } = this._pendingChunks.shift();
+      if (this.chunks.has(key) || this._inFlightByKey.has(key) || !this._neededChunkKeys.has(key)) {
+        continue;
+      }
+
+      if (this._requestChunkPayload(key, x, z)) {
+        requested++;
+      }
+    }
+    return requested;
   }
 
   _rebuildPendingAround(cx, cz) {
@@ -203,6 +207,15 @@ export class Terrain {
         needed.add(this._getChunkKey(cx + dx, cz + dz));
       }
     }
+    this._neededChunkKeys = needed;
+
+    // Cancel worker requests and drop ready payloads for chunks no longer needed
+    for (const [requestId, req] of this._inFlightById) {
+      if (!needed.has(req.key)) {
+        this._cancelInFlightRequest(requestId);
+      }
+    }
+    this._readyPayloads = this._readyPayloads.filter(entry => needed.has(entry.key));
 
     // Remove distant chunks
     for (const [key, mesh] of this.chunks) {
@@ -240,22 +253,29 @@ export class Terrain {
 
   preloadDrain(maxCount, cancelToken) {
     if (maxCount <= 0) return 0;
-    let built = 0;
-    while (this._pendingChunks.length > 0 && built < maxCount) {
+    let progress = 0;
+    while (progress < maxCount) {
       if (cancelToken?.cancelled) break;
-      const { key, x, z } = this._pendingChunks.shift();
-      if (!this.chunks.has(key)) {
-        const chunk = this._createChunk(x, z);
-        this.scene.add(chunk);
-        this.chunks.set(key, chunk);
-        built++;
+
+      const applied = this._applyReadyPayloads(1, cancelToken);
+      if (applied > 0) {
+        progress += applied;
+        continue;
       }
+
+      const requested = this._requestPendingChunks(1, cancelToken);
+      if (requested > 0) {
+        progress += requested;
+        continue;
+      }
+
+      break;
     }
-    return built;
+    return progress;
   }
 
   getPendingCount() {
-    return this._pendingChunks.length;
+    return this._pendingChunks.length + this._inFlightById.size + this._readyPayloads.length;
   }
 
   getChunkCount() {
@@ -266,15 +286,9 @@ export class Terrain {
     const cx = Math.round(playerPos.x / this.chunkSize);
     const cz = Math.round(playerPos.z / this.chunkSize);
 
-    // Build at most 1 pending chunk per frame to avoid frame spikes
-    if (this._pendingChunks.length > 0) {
-      const { key, x, z } = this._pendingChunks.shift();
-      if (!this.chunks.has(key)) {
-        const chunk = this._createChunk(x, z);
-        this.scene.add(chunk);
-        this.chunks.set(key, chunk);
-      }
-    }
+    // Build/apply at most 1 chunk payload per frame and request at most 1 new chunk
+    this._applyReadyPayloads(1);
+    this._requestPendingChunks(1);
 
     if (cx === this.lastChunkX && cz === this.lastChunkZ) return;
     this.lastChunkX = cx;

--- a/src/environment/chunkPayloadWorker.js
+++ b/src/environment/chunkPayloadWorker.js
@@ -1,0 +1,338 @@
+import { fbm2D, noise2D } from '../utils/noise.js';
+
+const TERRAIN_COLORS = {
+  shallow: [0.6, 0.5, 0.3],
+  mid: [0.3, 0.25, 0.2],
+  deep: [0.15, 0.12, 0.15],
+  abyss: [0.08, 0.05, 0.1],
+};
+
+const ORB_COLORS = [0x00ffaa, 0x00aaff, 0x8844ff, 0xff00aa, 0x44ffaa];
+const CORAL_SHALLOW_COLORS = [0xff6644, 0xff44aa, 0xffaa33, 0xff8866];
+const CORAL_DEEP_COLORS = [0x664455, 0x554466, 0x445566, 0x556644];
+
+const cancelledRequests = new Set();
+
+function getTerrainHeight(x, z) {
+  let h = fbm2D(x * 0.003, z * 0.003, 6) * 40;
+  h += Math.abs(noise2D(x * 0.01, z * 0.01)) * 15;
+
+  const trench = noise2D(x * 0.005 + 100, z * 0.005 + 100);
+  if (trench > 0.3) {
+    h -= (trench - 0.3) * 100;
+  }
+
+  return h;
+}
+
+function getTerrainBaseDepth(x, z) {
+  return -80 - Math.abs(fbm2D(x * 0.001, z * 0.001)) * 600;
+}
+
+function createTerrainPayload({ cx, cz, chunkSize, resolution }) {
+  const offsetX = cx * chunkSize;
+  const offsetZ = cz * chunkSize;
+  const vertsPerSide = resolution + 1;
+  const vertCount = vertsPerSide * vertsPerSide;
+
+  const positions = new Float32Array(vertCount * 3);
+  const colors = new Float32Array(vertCount * 3);
+  const colliderVertices = new Float32Array(vertCount * 3);
+
+  const step = chunkSize / resolution;
+  const half = chunkSize * 0.5;
+  let writeIdx = 0;
+
+  for (let iz = 0; iz <= resolution; iz++) {
+    const localZ = iz * step - half;
+    for (let ix = 0; ix <= resolution; ix++) {
+      const localX = ix * step - half;
+      const worldX = localX + offsetX;
+      const worldZ = localZ + offsetZ;
+      const h = getTerrainHeight(worldX, worldZ);
+      const baseDepth = getTerrainBaseDepth(worldX, worldZ);
+      const y = baseDepth + h;
+
+      positions[writeIdx] = localX;
+      positions[writeIdx + 1] = y;
+      positions[writeIdx + 2] = localZ;
+
+      colliderVertices[writeIdx] = worldX;
+      colliderVertices[writeIdx + 1] = y;
+      colliderVertices[writeIdx + 2] = worldZ;
+
+      const depth = -y;
+      let color;
+      if (depth < 80) {
+        color = TERRAIN_COLORS.shallow;
+      } else if (depth < 200) {
+        color = TERRAIN_COLORS.mid;
+      } else if (depth < 500) {
+        color = TERRAIN_COLORS.deep;
+      } else {
+        color = TERRAIN_COLORS.abyss;
+      }
+
+      const v = noise2D(worldX * 0.1, worldZ * 0.1) * 0.05;
+      colors[writeIdx] = color[0] + v;
+      colors[writeIdx + 1] = color[1] + v;
+      colors[writeIdx + 2] = color[2] + v;
+
+      writeIdx += 3;
+    }
+  }
+
+  const triCount = resolution * resolution * 2;
+  const indices = new Uint32Array(triCount * 3);
+  let indexWrite = 0;
+
+  for (let iz = 0; iz < resolution; iz++) {
+    for (let ix = 0; ix < resolution; ix++) {
+      const a = ix + vertsPerSide * iz;
+      const b = ix + vertsPerSide * (iz + 1);
+      const c = ix + 1 + vertsPerSide * (iz + 1);
+      const d = ix + 1 + vertsPerSide * iz;
+
+      indices[indexWrite++] = a;
+      indices[indexWrite++] = b;
+      indices[indexWrite++] = d;
+
+      indices[indexWrite++] = b;
+      indices[indexWrite++] = c;
+      indices[indexWrite++] = d;
+    }
+  }
+
+  const rockCount = 8 + Math.floor(Math.random() * 8);
+  const rockTransforms = new Float32Array(rockCount * 9);
+  const rockColliders = new Float32Array(rockCount * 4);
+
+  for (let i = 0; i < rockCount; i++) {
+    const localX = (Math.random() - 0.5) * chunkSize * 0.8;
+    const localZ = (Math.random() - 0.5) * chunkSize * 0.8;
+    const worldX = localX + offsetX;
+    const worldZ = localZ + offsetZ;
+    const h = getTerrainHeight(worldX, worldZ);
+    const baseDepth = getTerrainBaseDepth(worldX, worldZ);
+
+    const scaleX = 1 + Math.random() * 4;
+    const scaleY = scaleX * (0.5 + Math.random() * 0.8);
+    const scaleZ = scaleX;
+    const localY = baseDepth + h + scaleX * 0.3;
+
+    const transformIdx = i * 9;
+    rockTransforms[transformIdx] = localX;
+    rockTransforms[transformIdx + 1] = localY;
+    rockTransforms[transformIdx + 2] = localZ;
+    rockTransforms[transformIdx + 3] = scaleX;
+    rockTransforms[transformIdx + 4] = scaleY;
+    rockTransforms[transformIdx + 5] = scaleZ;
+    rockTransforms[transformIdx + 6] = Math.random();
+    rockTransforms[transformIdx + 7] = Math.random();
+    rockTransforms[transformIdx + 8] = Math.random();
+
+    const radius = (scaleX + scaleY + scaleZ) / 3;
+    const colliderIdx = i * 4;
+    rockColliders[colliderIdx] = worldX;
+    rockColliders[colliderIdx + 1] = localY;
+    rockColliders[colliderIdx + 2] = worldZ;
+    rockColliders[colliderIdx + 3] = radius;
+  }
+
+  return {
+    positions,
+    colors,
+    indices,
+    colliderVertices,
+    rockTransforms,
+    rockColliders,
+  };
+}
+
+function createCoralBranches(baseX, baseY, baseZ, size, out) {
+  function grow(px, py, pz, branchSize, depth) {
+    if (depth > 3 || branchSize < 0.15) return;
+
+    out.push({
+      x: px,
+      y: py + branchSize * 1.5,
+      z: pz,
+      size: branchSize,
+      rx: (Math.random() - 0.5) * 0.5,
+      rz: (Math.random() - 0.5) * 0.5,
+    });
+
+    const branches = 2 + Math.floor(Math.random() * 2);
+    for (let i = 0; i < branches; i++) {
+      const angle = (i / branches) * Math.PI * 2 + Math.random() * 0.5;
+      grow(
+        px + Math.cos(angle) * branchSize,
+        py + branchSize * 3,
+        pz + Math.sin(angle) * branchSize,
+        branchSize * 0.65,
+        depth + 1
+      );
+    }
+  }
+
+  grow(baseX, baseY, baseZ, size, 0);
+}
+
+function createFloraPayload({ cx, cz, chunkSize, floraDensityScale }) {
+  const offsetX = cx * chunkSize;
+  const offsetZ = cz * chunkSize;
+
+  const kelps = [];
+  const corals = [];
+  const orbs = [];
+  const orbLights = [];
+  const tubes = [];
+  const tubeTips = [];
+
+  const floraCount = Math.round((12 + Math.floor(Math.random() * 10)) * floraDensityScale);
+  let lightsInChunk = 0;
+
+  for (let i = 0; i < floraCount; i++) {
+    const x = (Math.random() - 0.5) * chunkSize * 0.9;
+    const z = (Math.random() - 0.5) * chunkSize * 0.9;
+    const worldX = x + offsetX;
+    const worldZ = z + offsetZ;
+
+    const terrainVal = noise2D(worldX * 0.003, worldZ * 0.003) * 40;
+    const baseDepth = -80 - Math.abs(noise2D(worldX * 0.001, worldZ * 0.001)) * 400;
+    const groundY = baseDepth + terrainVal;
+    const depth = -groundY;
+
+    const type = Math.random();
+
+    if (depth < 150 && type < 0.4) {
+      const segments = 8 + Math.floor(Math.random() * 6);
+      const height = 6 + Math.random() * 10;
+      const segHeight = height / segments;
+      const leafRotations = [];
+      for (let seg = 2; seg < segments; seg += 2) {
+        leafRotations.push({
+          y: seg * segHeight,
+          ry: Math.random() * Math.PI,
+        });
+      }
+
+      kelps.push({
+        x,
+        y: groundY,
+        z,
+        segments,
+        height,
+        radius: 0.08 + Math.random() * 0.05,
+        green: 0.3 + Math.random() * 0.2,
+        phase: Math.random() * Math.PI * 2,
+        leafRotations,
+      });
+    } else if (depth < 300 && type < 0.6) {
+      const palette = depth < 100 ? CORAL_SHALLOW_COLORS : CORAL_DEEP_COLORS;
+      const color = palette[Math.floor(Math.random() * palette.length)];
+      const baseSize = 0.4 + Math.random() * 0.4;
+      const branches = [];
+      createCoralBranches(x, groundY, z, baseSize, branches);
+      corals.push({
+        color,
+        emissiveFactor: depth > 200 ? 0.1 : 0,
+        branches,
+      });
+    } else if (depth > 100 && type < 0.8) {
+      const color = ORB_COLORS[Math.floor(Math.random() * ORB_COLORS.length)];
+      const oy = groundY + 1 + Math.random() * 5;
+      orbs.push({
+        x,
+        y: oy,
+        z,
+        size: 0.1 + Math.random() * 0.3,
+        color,
+      });
+
+      if (lightsInChunk < 2 && Math.random() < 0.1) {
+        orbLights.push({
+          x,
+          y: oy,
+          z,
+          color,
+          intensity: 0.8,
+          distance: 25,
+        });
+        lightsInChunk++;
+      }
+    } else if (depth > 200) {
+      const count = 3 + Math.floor(Math.random() * 5);
+      for (let j = 0; j < count; j++) {
+        const height = 1 + Math.random() * 3;
+        const tx = x + (Math.random() - 0.5) * 0.5;
+        const tz = z + (Math.random() - 0.5) * 0.5;
+        const rx = (Math.random() - 0.5) * 0.15;
+        const rz = (Math.random() - 0.5) * 0.15;
+
+        tubes.push({ x: tx, y: groundY + height * 0.5, z: tz, height, rx, rz });
+        tubeTips.push({ x: tx, y: groundY + height, z: tz });
+      }
+    }
+  }
+
+  return {
+    kelps,
+    corals,
+    orbs,
+    orbLights,
+    tubes,
+    tubeTips,
+  };
+}
+
+self.onmessage = (event) => {
+  const data = event.data;
+  if (!data || typeof data !== 'object') return;
+
+  if (data.type === 'cancel') {
+    cancelledRequests.add(data.requestId);
+    return;
+  }
+
+  const { requestId } = data;
+  if (cancelledRequests.has(requestId)) {
+    cancelledRequests.delete(requestId);
+    return;
+  }
+
+  if (data.type === 'generateTerrain') {
+    const payload = createTerrainPayload(data);
+    if (cancelledRequests.has(requestId)) {
+      cancelledRequests.delete(requestId);
+      return;
+    }
+
+    self.postMessage({
+      type: 'terrainPayload',
+      requestId,
+      key: data.key,
+      cx: data.cx,
+      cz: data.cz,
+      payload,
+    });
+    return;
+  }
+
+  if (data.type === 'generateFlora') {
+    const payload = createFloraPayload(data);
+    if (cancelledRequests.has(requestId)) {
+      cancelledRequests.delete(requestId);
+      return;
+    }
+
+    self.postMessage({
+      type: 'floraPayload',
+      requestId,
+      key: data.key,
+      cx: data.cx,
+      cz: data.cz,
+      payload,
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- offloads CPU-heavy terrain chunk payload generation (vertices, colors, indices, collider source vertices, and rock instance/collider data) to a module Web Worker
- offloads flora chunk payload generation (kelp/coral/orb/tube placement and parameters) to the same worker while keeping Three.js object construction on the main thread
- preserves bounded pending chunk queue/view-distance behavior and adds request tracking for cancelable worker jobs so stale results are ignored

## Validation
- npm run build

Fixes #97