### PR TITLE
feat: photorealistic overhaul of Parasite creature with 3-tier LOD

### DIFF
--- a/src/creatures/Parasite.js
+++ b/src/creatures/Parasite.js
@@ -505,7 +505,7 @@ export class Parasite {
       }
       const veinCurve = new THREE.CatmullRomCurve3(veinPoints);
       const veinGeo = new THREE.TubeGeometry(veinCurve, profile.veinSegs, 0.005, 6, false);
-      const vein = new THREE.Mesh(veinGeo, veinMat);
+      const vein = new THREE.Mesh(veinGeo, veinMat.clone());
       veins.push(vein);
       tierGroup.add(vein);
 
@@ -656,9 +656,10 @@ export class Parasite {
   }
 
   _animateProboscisIK(probGroup, playerPos, t) {
-    _tmpVec3B.copy(playerPos).sub(this.group.position);
-    const localDir = this.group.worldToLocal(_tmpVec3B.add(this.group.position));
-    this._proboscisTarget.lerp(localDir.normalize(), 0.03);
+    this.group.updateMatrixWorld(true);
+    _tmpVec3B.copy(playerPos);
+    this.group.worldToLocal(_tmpVec3B);
+    this._proboscisTarget.lerp(_tmpVec3B.normalize(), 0.03);
     const target = this._proboscisTarget;
 
     const searchPhase = Math.sin(t * 1.2) * 0.3;


### PR DESCRIPTION
## Photorealistic Parasite Creature Overhaul

Complete rewrite of `src/creatures/Parasite.js` implementing all requirements from issue #69.

### Geometry Improvements
- **Main sac**: SphereGeometry(0.4, 48, 32) with multi-frequency organic lumpy displacement
- **Secondary sacs**: (size, 24, 16) with independent lumpy displacement
- **Proboscis**: 14-segment multi-articulated tube with 6 barbed tips, backward-facing spines, hooked tip (TorusGeometry)
- **Tendrils**: 8 TubeGeometry-based organic curves with CatmullRomCurve3, 12 segments, 8 radial segments
- **Veins**: 8 veins with 8 segments each, 3 branches per vein creating a branching capillary network
- **Anchor pad**: CircleGeometry on ventral surface with 8 pore ring structures
- **Inner fluid structures**: Semi-transparent inner sac visible through translucent outer membrane

### Animation System
- **Per-vertex sac deformation**: Vertex shader inflation waves traveling across surface (not uniform scale)
- **Proboscis IK**: Multi-axis articulated probing/searching toward player at near LOD
- **Tendril grasping**: Individual momentum-based secondary motion with sinusoidal sway
- **Vein pulse**: Animated emissiveIntensity wave traveling through vein network
- **Secondary sac rhythm**: Each sac on independent heartbeat phase with jelly-like wobble
- **Feeding animation**: Slow growth pulsation cycle
- **Player proximity reaction**: Proboscis extends/searches toward player, sacs pulse faster
- **Procedural variation**: Randomized sac sizes, heartbeat phases, tendril lengths, wobble phases

### LOD System (3 tiers using shared lodUtils constants)
- **Near (0–42m)**: Full per-vertex shader deformation, proboscis IK, all 8 tendrils + 8 veins with branches, anchor pad
- **Medium (42–86m)**: Uniform sac scale pulse, simplified proboscis sway, 4 tendrils, 4 veins, reduced segments
- **Far (86m+)**: Static sac shape, no tendrils/veins, simplified blob silhouette with MeshStandardMaterial

### GPU Optimization
- **Vertex shader sac pulsation**: Inflation waves computed in vertex shader via onBeforeCompile injection
- **Zero per-frame allocations**: Pre-allocated Vector3 temps at module level
- **No point lights**: Removed PointLight; vein glow via animated emissive only
- **BufferGeometry only**: No dispose/recreate cycles
- **Far tier uses MeshStandardMaterial**: Drops clearcoat/transmission for GPU savings
- **Animation throttling**: Tendril animation interval scales with LOD tier distance

### Material Enhancements
- **Subsurface scattering**: MeshPhysicalMaterial with transmission=0.35 + thickness=0.5
- **Animated emissive**: Vein pulse wave via emissiveIntensity modulation + emissiveMap
- **Normal maps**: Procedural canvas-generated capillary/vein normal map on sacs, barb serration normal map on proboscis
- **Fresnel rim-light**: Shader-injected fresnel for sac silhouette visibility
- **Wet specular**: clearcoat=0.95, clearcoatRoughness=0.05 for glistening tissue

Fixes #69