### PR TITLE
fix: Anglerfish shader compilation failure and jaw material TypeError spam

### DIFF
--- a/src/creatures/Anglerfish.js
+++ b/src/creatures/Anglerfish.js
@@ -293,6 +293,7 @@ export class Anglerfish {
       jawGeo.rotateZ(-Math.PI * 0.5);
       jawGeo.translate(0.62, 0, 0);
       jawMat = bodyMat.clone();
+      jawMat.userData = {};
       jawMat.emissiveIntensity = isNear ? 0.3 : 0.55;
       if (isNear) this._applyJawShader(jawMat);
       jaw = new THREE.Mesh(jawGeo, jawMat);
@@ -511,12 +512,18 @@ float scaleRelief = sin(position.x * 25.0 + position.y * 17.0 + position.z * 21.
 transformed += normal * scaleRelief * uFlexIntensity;`
         );
 
-      shader.fragmentShader = shader.fragmentShader.replace(
-        '#include <emissivemap_fragment>',
-        `#include <emissivemap_fragment>
+      shader.fragmentShader = shader.fragmentShader
+        .replace(
+          '#include <common>',
+          `#include <common>
+uniform float uBodyFlex;`
+        )
+        .replace(
+          '#include <emissivemap_fragment>',
+          `#include <emissivemap_fragment>
 float rim = pow(1.0 - abs(dot(normalize(vViewPosition), normal)), 2.3);
 totalEmissiveRadiance += vec3(0.06, 0.16, 0.12) * rim * (0.7 + uBodyFlex * 0.7);`
-      );
+        );
 
       material.userData.shader = shader;
     };


### PR DESCRIPTION
## Summary

Fixes two related shader/uniform bugs in `Anglerfish.js` that caused:
1. **Shader compilation error** — `uBodyFlex` undeclared in fragment shader
2. **18,000+ TypeError errors per minute** — cloned jaw material inheriting body shader uniforms

## Root Causes

### Fragment shader missing uniform declaration
The `_applyBodyShader` method's fragment patch references `uBodyFlex` but only declares the uniform in the vertex shader (`#include <common>` replacement). GLSL requires each shader stage to independently declare its uniforms.

**Fix**: Add a `#include <common>` replacement in the fragment shader that declares `uniform float uBodyFlex;`.

### Jaw material clone inheriting wrong shaderUniforms
`jawMat = bodyMat.clone()` copies `userData` (including `shaderUniforms` from `_applyBodyShader`). For the medium LOD tier, `_applyJawShader` is not called, so the jaw material has body uniforms (`uFishTime`, `uBodyFlex`, etc.) but **not** `uJawOpen`. The animation guard `tier.jawMaterial?.userData?.shaderUniforms` passes (shaderUniforms exists from the clone), but `shaderUniforms.uJawOpen` is `undefined`, causing `TypeError: Cannot set properties of undefined (setting 'value')` every single frame.

**Fix**: Clear `userData` after cloning (`jawMat.userData = {}`) so the medium-tier guard correctly skips shader-uniform updates.

## Evidence
- 45,515+ console errors accumulated in ~7 minutes of gameplay
- Error propagates from creature update loop, disrupting HUD/audio/render updates downstream
- FPS impact: contributes to frame-time variance and console logging overhead