### PR TITLE
fix: NeedleFish shader compilation failure — uBodyFlex undeclared in fragment

### DIFF
--- a/src/creatures/NeedleFish.js
+++ b/src/creatures/NeedleFish.js
@@ -121,15 +121,21 @@ float scaleDetail = sin(position.y * 23.0 + position.x * 17.0) * 0.007;
 transformed += normal * scaleDetail;`
         );
 
-      shader.fragmentShader = shader.fragmentShader.replace(
-        '#include <emissivemap_fragment>',
-        `#include <emissivemap_fragment>
+      shader.fragmentShader = shader.fragmentShader
+        .replace(
+          '#include <common>',
+          `#include <common>
+uniform float uBodyFlex;`
+        )
+        .replace(
+          '#include <emissivemap_fragment>',
+          `#include <emissivemap_fragment>
 // Fresnel rim-light for silhouette visibility in dark water
 float rim = pow(1.0 - abs(dot(normalize(vViewPosition), normal)), 2.5);
 totalEmissiveRadiance += vec3(0.07, 0.03, 0.12) * rim * 0.6;
 // Lateral line threat glow
 totalEmissiveRadiance += vec3(0.35, 0.0, 0.25) * uBodyFlex * 0.25 * rim;`
-      );
+        );
 
       mat.userData.shader = shader;
     };


### PR DESCRIPTION
## Summary

Fixes NeedleFish body shader compilation failure caused by `uBodyFlex` being referenced in the fragment shader without being declared.

## Root Cause

The `_applyBodyShader` method patches the fragment shader to add a lateral-line threat glow effect using `uBodyFlex`, but only declares the `uniform float uBodyFlex;` in the vertex shader (`#include <common>` replacement). GLSL requires each shader stage to declare its own uniforms independently.

This causes `THREE.WebGLProgram: Shader Error 0 — VALIDATE_STATUS false` with `'uBodyFlex' : undeclared identifier` every time a NeedleFish spawns, followed by `WebGL: INVALID_OPERATION: useProgram: program not valid` warnings.

## Fix

Add a `#include <common>` replacement in the fragment shader that declares `uniform float uBodyFlex;`, matching the pattern used in the vertex shader.

## Evidence
- Console error: `THREE.WebGLProgram: Shader Error 1282 — VALIDATE_STATUS false`
- Fragment line: `totalEmissiveRadiance += vec3(0.35, 0.0, 0.25) * uBodyFlex * 0.25 * rim;`
- Errors repeat for every NeedleFish instance spawned