### PR TITLE
feat: overhaul spinal eel creature

### DIFF
--- a/src/creatures/SpinalEel.js
+++ b/src/creatures/SpinalEel.js
@@ -467,8 +467,7 @@ function _shapeTubeGeometry(geometry, length) {
   // NOTE: do NOT bake the orientation flip into the geometry — the shader reads
   // raw geometry positions to compute eelProgress (clamp(-x/uLength, 0, 1)).
   // geometry.rotateZ(PI) would negate X, collapsing progress to zero on
-  // near/medium LODs and breaking wave/glow animation.  The visual flip is
-  // applied instead as body.rotation.z = Math.PI on the mesh object.
+  // near/medium LODs and breaking wave/glow animation.
 }
 
 function _shapeHeadGeometry(geometry, detailEnabled) {


### PR DESCRIPTION
Implements the SpinalEel overhaul for Epic #53 sub-issue #75.

Summary:
- Replaces the segmented body with a continuous tube-based spine and a three-tier LOD rig.
- Adds higher-detail head, jaws, eyes, ribs, spinal processes, vertebral fins, and tail-fin detail.
- Moves full-body undulation, muscle bulge, emissive glow, Fresnel rim support, and fin flutter into shader-driven animation while keeping near and medium rig motion allocation-free.
- Adds coiling, jaw ratchet, skull tilt, asymmetric tail stroke, breathing, inertia, and player-proximity reactions.

Validation:
- npm install
- npm run build

Fixes #75