### PR TITLE
fix: add missing uniform declarations in PipeOrgan resonance shader

### DIFF
--- a/src/creatures/PipeOrgan.js
+++ b/src/creatures/PipeOrgan.js
@@ -94,6 +94,9 @@ function _applyResonanceShaderInstanced(mat, uTime, uResA, uRetractT) {
       '#include <common>',
       [
         '#include <common>',
+        'uniform float uTime;',
+        'uniform float uResA;',
+        'uniform float uRetractT;',
         'attribute float aResFreq;',
         'attribute float aPhase;',
         'attribute float aRadius;',


### PR DESCRIPTION
## Problem

`_applyResonanceShaderInstanced()` in `PipeOrgan.js` added the uniforms `uTime`, `uResA`, and `uRetractT` to `shader.uniforms` but never injected their GLSL `uniform float` declarations into the vertex shader source. This caused a WebGL shader compile/validate error:

```
ERROR: 0:567: 'uTime' : undeclared identifier
ERROR: 0:568: 'uResA' : undeclared identifier
ERROR: 0:568: 'uRetractT' : undeclared identifier
```

## Root Cause

The `#include <common>` replacement block only declared the instanced `attribute` variables (`aResFreq`, `aPhase`, `aRadius`) but omitted the corresponding `uniform float` declarations. Compare with `_applyMembraneShader()` which correctly prepends all three uniform declarations.

## Fix

Added the three missing `uniform float` declarations (`uTime`, `uResA`, `uRetractT`) to the `#include <common>` replacement in `_applyResonanceShaderInstanced()`.

Fixes #160