### PR TITLE
feat: photorealistic seafloor materials with wet PBR layering

### DIFF
--- a/src/environment/Flora.js
+++ b/src/environment/Flora.js
@@ -45,19 +45,23 @@ export class Flora {
       emissiveIntensity: 0.8,
       transparent: true,
       opacity: 0.7,
+      roughness: 0.3,
     });
 
-    // Shared geometry/materials for instanced tube worms
+    // Shared geometry/materials for instanced tube worms — wet organic look
     this._tubeGeo = new THREE.CylinderGeometry(0.04, 0.06, 1, 6);
     this._tubeMat = new THREE.MeshStandardMaterial({
       color: 0x884422,
-      roughness: 0.9,
+      roughness: 0.4,
+      metalness: 0.05,
     });
     this._tipGeo = new THREE.SphereGeometry(0.12, 6, 6);
     this._tipMat = new THREE.MeshStandardMaterial({
       color: 0xff3300,
       emissive: 0xff2200,
-      emissiveIntensity: 0.3,
+      emissiveIntensity: 0.4,
+      roughness: 0.25,
+      metalness: 0.1,
     });
 
     window.addEventListener('qualitychange', (e) => {
@@ -188,11 +192,25 @@ export class Flora {
     const geo = new THREE.TubeGeometry(curve, kelpData.segments, kelpData.radius, 4, false);
     const mat = new THREE.MeshStandardMaterial({
       color: new THREE.Color(0.1, kelpData.green, 0.05),
-      roughness: 0.8,
+      roughness: 0.5,
+      metalness: 0.02,
       transparent: true,
-      opacity: 0.8,
+      opacity: 0.85,
       side: THREE.DoubleSide,
+      emissive: new THREE.Color(0.02, kelpData.green * 0.15, 0.01),
+      emissiveIntensity: 0.5,
     });
+    mat.onBeforeCompile = (shader) => {
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <emissivemap_fragment>',
+        `#include <emissivemap_fragment>
+        {
+          float NdV = abs(dot(normal, normalize(vViewPosition)));
+          float rim = pow(1.0 - NdV, 2.0);
+          totalEmissiveRadiance += diffuseColor.rgb * rim * 0.15;
+        }`
+      );
+    };
 
     const kelp = new THREE.Mesh(geo, mat);
     kelp.position.set(kelpData.x, kelpData.y, kelpData.z);
@@ -222,7 +240,8 @@ export class Flora {
       : new THREE.Color(0);
     const mat = new THREE.MeshStandardMaterial({
       color: coralData.color,
-      roughness: 0.7,
+      roughness: 0.45,
+      metalness: 0.05,
       emissive,
     });
 

--- a/src/environment/Terrain.js
+++ b/src/environment/Terrain.js
@@ -45,14 +45,10 @@ export class Terrain {
       }
     });
 
-    // Shared geometry and material for rocks (avoids per-chunk allocation)
-    this._rockGeo = new THREE.DodecahedronGeometry(1, 1);
-    this._rockMat = new THREE.MeshStandardMaterial({
-      color: 0x333340,
-      roughness: 0.95,
-      metalness: 0.05,
-      flatShading: true,
-    });
+    // Multiple rock geometries for visual variety + wet PBR materials
+    this._rockGeos = this._createRockGeometries();
+    this._rockMat = this._createRockMaterial();
+    this._terrainMat = this._createTerrainMaterial();
   }
 
   /**
@@ -61,6 +57,198 @@ export class Terrain {
    */
   setPhysicsWorld(physicsWorld) {
     this._physicsWorld = physicsWorld;
+  }
+
+  _createRockGeometries() {
+    const geos = [];
+    geos.push(this._distortGeo(new THREE.DodecahedronGeometry(1, 1), 0.15));
+    geos.push(this._distortGeo(new THREE.IcosahedronGeometry(1, 2), 0.10));
+    const slab = new THREE.DodecahedronGeometry(1, 0);
+    const sp = slab.attributes.position;
+    for (let i = 0; i < sp.count; i++) sp.setY(i, sp.getY(i) * 0.4);
+    geos.push(this._distortGeo(slab, 0.08));
+    const spire = new THREE.OctahedronGeometry(1, 1);
+    const pp = spire.attributes.position;
+    for (let i = 0; i < pp.count; i++) pp.setY(i, pp.getY(i) * 1.6);
+    geos.push(this._distortGeo(spire, 0.12));
+    return geos;
+  }
+
+  _distortGeo(geo, amount) {
+    const pos = geo.attributes.position;
+    for (let i = 0; i < pos.count; i++) {
+      const x = pos.getX(i), y = pos.getY(i), z = pos.getZ(i);
+      const h = Math.sin(x * 12.9898 + y * 78.233 + z * 45.164) * 43758.5453;
+      const d = (h - Math.floor(h)) * amount;
+      const len = Math.sqrt(x * x + y * y + z * z) || 1;
+      pos.setXYZ(i, x + (x / len) * d, y + (y / len) * d, z + (z / len) * d);
+    }
+    geo.computeVertexNormals();
+    return geo;
+  }
+
+  _createRockMaterial() {
+    const mat = new THREE.MeshStandardMaterial({
+      color: 0x888890,
+      roughness: 0.55,
+      metalness: 0.08,
+    });
+    mat.onBeforeCompile = (shader) => {
+      shader.vertexShader = shader.vertexShader.replace(
+        '#include <common>',
+        `#include <common>
+        varying vec3 vWPos;`
+      );
+      shader.vertexShader = shader.vertexShader.replace(
+        '#include <begin_vertex>',
+        `#include <begin_vertex>
+        {
+          vec4 _wp = vec4(transformed, 1.0);
+          #ifdef USE_INSTANCING
+            _wp = instanceMatrix * _wp;
+          #endif
+          _wp = modelMatrix * _wp;
+          vWPos = _wp.xyz;
+        }`
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <common>',
+        `#include <common>
+        varying vec3 vWPos;
+        float _rh(vec3 p) {
+          p = fract(p * vec3(443.897, 441.423, 437.195));
+          p += dot(p, p.yzx + 19.19);
+          return fract((p.x + p.y) * p.z);
+        }
+        float _rn(vec3 p) {
+          vec3 i = floor(p); vec3 f = fract(p);
+          f = f * f * (3.0 - 2.0 * f);
+          return mix(
+            mix(mix(_rh(i), _rh(i+vec3(1,0,0)), f.x),
+                mix(_rh(i+vec3(0,1,0)), _rh(i+vec3(1,1,0)), f.x), f.y),
+            mix(mix(_rh(i+vec3(0,0,1)), _rh(i+vec3(1,0,1)), f.x),
+                mix(_rh(i+vec3(0,1,1)), _rh(i+vec3(1,1,1)), f.x), f.y), f.z);
+        }`
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <normal_fragment_maps>',
+        `#include <normal_fragment_maps>
+        {
+          float eps = 0.08, sc = 2.0;
+          float h0 = _rn(vWPos * sc);
+          float hx = _rn((vWPos + vec3(eps,0,0)) * sc);
+          float hz = _rn((vWPos + vec3(0,0,eps)) * sc);
+          vec3 grad = vec3((hx - h0) / eps, 0.0, (hz - h0) / eps);
+          normal = normalize(normal - grad * 0.4);
+        }`
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <roughnessmap_fragment>',
+        `#include <roughnessmap_fragment>
+        {
+          float depth = -vWPos.y;
+          float wetness = smoothstep(500.0, 60.0, depth);
+          roughnessFactor *= mix(1.0, 0.35, wetness);
+          roughnessFactor += _rn(vWPos * 8.0) * 0.08 - 0.04;
+          roughnessFactor = clamp(roughnessFactor, 0.1, 1.0);
+        }`
+      );
+    };
+    return mat;
+  }
+
+  _createTerrainMaterial() {
+    const mat = new THREE.MeshStandardMaterial({
+      vertexColors: true,
+      roughness: 0.85,
+      metalness: 0.05,
+    });
+    mat.onBeforeCompile = (shader) => {
+      shader.vertexShader = shader.vertexShader.replace(
+        '#include <common>',
+        `#include <common>
+        varying vec3 vWPos;
+        varying float vSlope;`
+      );
+      shader.vertexShader = shader.vertexShader.replace(
+        '#include <begin_vertex>',
+        `#include <begin_vertex>
+        {
+          vec4 _wp = modelMatrix * vec4(transformed, 1.0);
+          vWPos = _wp.xyz;
+          vec3 wNrm = normalize(mat3(modelMatrix) * objectNormal);
+          vSlope = 1.0 - abs(wNrm.y);
+        }`
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <common>',
+        `#include <common>
+        varying vec3 vWPos;
+        varying float vSlope;
+        float _th(vec3 p) {
+          p = fract(p * vec3(443.897, 441.423, 437.195));
+          p += dot(p, p.yzx + 19.19);
+          return fract((p.x + p.y) * p.z);
+        }
+        float _tn(vec3 p) {
+          vec3 i = floor(p); vec3 f = fract(p);
+          f = f * f * (3.0 - 2.0 * f);
+          return mix(
+            mix(mix(_th(i), _th(i+vec3(1,0,0)), f.x),
+                mix(_th(i+vec3(0,1,0)), _th(i+vec3(1,1,0)), f.x), f.y),
+            mix(mix(_th(i+vec3(0,0,1)), _th(i+vec3(1,0,1)), f.x),
+                mix(_th(i+vec3(0,1,1)), _th(i+vec3(1,1,1)), f.x), f.y), f.z);
+        }
+        float _tfbm(vec3 p) {
+          float s = 0.0, a = 1.0, f = 1.0, m = 0.0;
+          for (int i = 0; i < 4; i++) {
+            s += _tn(p * f) * a; m += a; f *= 2.0; a *= 0.5;
+          }
+          return s / m;
+        }`
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <color_fragment>',
+        `#include <color_fragment>
+        {
+          float depth = -vWPos.y;
+          vec3 rockCol = vec3(0.25, 0.22, 0.2) + _tn(vWPos * 0.5) * 0.06;
+          vec3 siltCol = vec3(0.18, 0.15, 0.13) + _tn(vWPos * 0.3 + 100.0) * 0.04;
+          vec3 algaeCol = vec3(0.12, 0.2, 0.08) + _tn(vWPos * 0.8 + 200.0) * 0.05;
+          float algaeMask = smoothstep(200.0, 80.0, depth) * (1.0 - vSlope);
+          float rockMask = smoothstep(0.3, 0.7, vSlope);
+          float siltMask = max(1.0 - rockMask - algaeMask, 0.0);
+          vec3 layered = rockCol * rockMask + siltCol * siltMask + algaeCol * algaeMask;
+          diffuseColor.rgb = mix(layered, diffuseColor.rgb, 0.4);
+          diffuseColor.rgb *= 0.9 + _tfbm(vWPos * 4.0) * 0.2;
+        }`
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <normal_fragment_maps>',
+        `#include <normal_fragment_maps>
+        {
+          float eps = 0.1, sc = 1.5;
+          float h0 = _tfbm(vWPos * sc);
+          float hx = _tfbm((vWPos + vec3(eps,0,0)) * sc);
+          float hz = _tfbm((vWPos + vec3(0,0,eps)) * sc);
+          vec3 grad = vec3((hx - h0) / eps, 0.0, (hz - h0) / eps);
+          normal = normalize(normal - grad * 0.35);
+        }`
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <roughnessmap_fragment>',
+        `#include <roughnessmap_fragment>
+        {
+          float depth = -vWPos.y;
+          float wetness = smoothstep(500.0, 60.0, depth);
+          roughnessFactor *= mix(1.0, 0.45, wetness);
+          roughnessFactor += vSlope * 0.1;
+          roughnessFactor += _tn(vWPos * 6.0) * 0.1 - 0.05;
+          roughnessFactor = clamp(roughnessFactor, 0.15, 1.0);
+        }`
+      );
+    };
+    return mat;
   }
 
   _getChunkKey(cx, cz) {
@@ -108,22 +296,66 @@ export class Terrain {
     const count = payload.rockTransforms.length / 9;
     if (count <= 0) return;
 
-    const dummy = new THREE.Object3D();
-    const instancedRocks = new THREE.InstancedMesh(this._rockGeo, this._rockMat, count);
-    instancedRocks.castShadow = true;
-    instancedRocks.receiveShadow = true;
-
+    const numTypes = this._rockGeos.length;
+    const groups = Array.from({ length: numTypes }, () => []);
     for (let i = 0; i < count; i++) {
-      const idx = i * 9;
-      dummy.position.set(payload.rockTransforms[idx], payload.rockTransforms[idx + 1], payload.rockTransforms[idx + 2]);
-      dummy.scale.set(payload.rockTransforms[idx + 3], payload.rockTransforms[idx + 4], payload.rockTransforms[idx + 5]);
-      dummy.rotation.set(payload.rockTransforms[idx + 6], payload.rockTransforms[idx + 7], payload.rockTransforms[idx + 8]);
-      dummy.updateMatrix();
-      instancedRocks.setMatrixAt(i, dummy.matrix);
+      const t = payload.rockTypes ? payload.rockTypes[i] % numTypes : i % numTypes;
+      groups[t].push(i);
     }
 
-    instancedRocks.instanceMatrix.needsUpdate = true;
-    parent.add(instancedRocks);
+    const dummy = new THREE.Object3D();
+    const tmpColor = new THREE.Color();
+
+    for (let t = 0; t < numTypes; t++) {
+      const ids = groups[t];
+      if (ids.length === 0) continue;
+
+      const inst = new THREE.InstancedMesh(this._rockGeos[t], this._rockMat, ids.length);
+      inst.castShadow = true;
+      inst.receiveShadow = true;
+
+      if (payload.rockColors) {
+        inst.instanceColor = new THREE.InstancedBufferAttribute(
+          new Float32Array(ids.length * 3), 3
+        );
+      }
+
+      for (let j = 0; j < ids.length; j++) {
+        const i = ids[j];
+        const idx = i * 9;
+        dummy.position.set(
+          payload.rockTransforms[idx],
+          payload.rockTransforms[idx + 1],
+          payload.rockTransforms[idx + 2]
+        );
+        dummy.scale.set(
+          payload.rockTransforms[idx + 3],
+          payload.rockTransforms[idx + 4],
+          payload.rockTransforms[idx + 5]
+        );
+        dummy.rotation.set(
+          payload.rockTransforms[idx + 6],
+          payload.rockTransforms[idx + 7],
+          payload.rockTransforms[idx + 8]
+        );
+        dummy.updateMatrix();
+        inst.setMatrixAt(j, dummy.matrix);
+
+        if (payload.rockColors) {
+          const ci = i * 3;
+          tmpColor.setRGB(
+            payload.rockColors[ci],
+            payload.rockColors[ci + 1],
+            payload.rockColors[ci + 2]
+          );
+          inst.setColorAt(j, tmpColor);
+        }
+      }
+
+      inst.instanceMatrix.needsUpdate = true;
+      if (inst.instanceColor) inst.instanceColor.needsUpdate = true;
+      parent.add(inst);
+    }
 
     // Create physics sphere colliders for each rock from worker payload
     if (this._physicsWorld) {
@@ -159,12 +391,7 @@ export class Terrain {
       geo.setIndex(new THREE.BufferAttribute(payload.indices, 1));
       geo.computeVertexNormals();
 
-      const mat = new THREE.MeshStandardMaterial({
-        vertexColors: true,
-        roughness: 0.9,
-        metalness: 0.1,
-        flatShading: true,
-      });
+      const mat = this._terrainMat;
 
       const mesh = new THREE.Mesh(geo, mat);
       mesh.position.set(cx * this.chunkSize, 0, cz * this.chunkSize);
@@ -228,7 +455,6 @@ export class Terrain {
         }
         this.scene.remove(mesh);
         mesh.geometry.dispose();
-        mesh.material.dispose();
         this.chunks.delete(key);
       }
     }

--- a/src/environment/chunkPayloadWorker.js
+++ b/src/environment/chunkPayloadWorker.js
@@ -106,6 +106,8 @@ function createTerrainPayload({ cx, cz, chunkSize, resolution }) {
   const rockCount = 8 + Math.floor(Math.random() * 8);
   const rockTransforms = new Float32Array(rockCount * 9);
   const rockColliders = new Float32Array(rockCount * 4);
+  const rockTypes = new Uint8Array(rockCount);
+  const rockColors = new Float32Array(rockCount * 3);
 
   for (let i = 0; i < rockCount; i++) {
     const localX = (Math.random() - 0.5) * chunkSize * 0.8;
@@ -137,6 +139,25 @@ function createTerrainPayload({ cx, cz, chunkSize, resolution }) {
     rockColliders[colliderIdx + 1] = localY;
     rockColliders[colliderIdx + 2] = worldZ;
     rockColliders[colliderIdx + 3] = radius;
+
+    rockTypes[i] = Math.floor(Math.random() * 4);
+
+    const rockDepth = -localY;
+    const ci = i * 3;
+    const rv = Math.random() * 0.08;
+    if (rockDepth < 100) {
+      rockColors[ci] = 0.35 + rv;
+      rockColors[ci + 1] = 0.32 + rv * 0.8;
+      rockColors[ci + 2] = 0.28 + rv * 0.5;
+    } else if (rockDepth < 300) {
+      rockColors[ci] = 0.25 + rv;
+      rockColors[ci + 1] = 0.22 + rv * 0.7;
+      rockColors[ci + 2] = 0.22 + rv;
+    } else {
+      rockColors[ci] = 0.15 + rv;
+      rockColors[ci + 1] = 0.12 + rv * 0.5;
+      rockColors[ci + 2] = 0.16 + rv;
+    }
   }
 
   return {
@@ -146,6 +167,8 @@ function createTerrainPayload({ cx, cz, chunkSize, resolution }) {
     colliderVertices,
     rockTransforms,
     rockColliders,
+    rockTypes,
+    rockColors,
   };
 }
 


### PR DESCRIPTION
## Summary

Replace flat-shaded terrain and simple flora materials with wet PBR layering, procedural detail, and geometry variation for a photorealistic seafloor.

### Terrain material overhaul
- Removed `flatShading: true` for smooth interpolated normals
- Added `onBeforeCompile` shader injection with:
  - **Triplanar procedural normals** via FBM noise gradient perturbation
  - **Slope-based albedo blending** — rock (steep), silt (flat deep), algae (flat shallow)
  - **Depth-dependent wetness** — lower roughness at shallower depths
  - **Micro-detail** FBM modulation on diffuse color
- Shared terrain material across all chunks (single shader compilation)

### Rock geometry variation
- 4 distinct geometry types: angular boulder, rounded rock, flat slab, tall spire
- Organic vertex distortion on each geometry for natural shapes
- Per-instance depth-based color variation via `InstancedBufferAttribute`
- Rock material with procedural normal perturbation + depth wetness via `onBeforeCompile`

### Flora material improvements
- **Kelp**: roughness 0.8→0.5 (wet/slimy), added emissive subsurface + rim-glow translucency approximation via `onBeforeCompile`
- **Coral**: roughness 0.7→0.45, added metalness 0.05 for wet stone look
- **Tube worms**: roughness 0.9→0.4 with metalness for wet organic surface
- **Tube tips**: brighter emissive (0.4), very low roughness (0.25) for specular highlight
- **Bio-orbs**: added roughness 0.3 for visible light interaction

### Worker payload
- Added `rockTypes` (Uint8Array) and `rockColors` (Float32Array) to terrain payload
- Each rock gets a random geometry type 0-3 and depth-band-dependent color

### Performance
- Shared terrain material avoids per-chunk shader recompilation
- Rock geometries are shared across all chunks (4 total, reused via InstancedMesh)
- No new texture allocations — all detail is procedural in the shader
- FBM noise uses 4 octaves max, bounded by `for` loop

Fixes #158