### PR TITLE
fix: prevent undefined normalScale warnings in Amalgam materials

### DIFF
--- a/src/creatures/Amalgam.js
+++ b/src/creatures/Amalgam.js
@@ -449,7 +449,7 @@ export class Amalgam {
       emissive: 0x502040,
       emissiveIntensity: isFar ? 0 : 0.7,
       normalMap: fleshNormal,
-      normalScale: isNear ? new THREE.Vector2(0.6, 0.6) : undefined,
+      ...(isNear && { normalScale: new THREE.Vector2(0.6, 0.6) }),
       transmission: isNear ? 0.15 : 0,
       thickness: isNear ? 0.8 : 0,
     });
@@ -471,7 +471,7 @@ export class Amalgam {
       emissive: 0x504030,
       emissiveIntensity: isFar ? 0 : 0.5,
       normalMap: boneNormal,
-      normalScale: isNear ? new THREE.Vector2(0.5, 0.5) : undefined,
+      ...(isNear && { normalScale: new THREE.Vector2(0.5, 0.5) }),
     });
 
     let organMat = new THREE.MeshPhysicalMaterial({


### PR DESCRIPTION
## Summary

Fixes the 4 Three.js warnings caused by Amalgam passing `normalScale: undefined` to `MeshPhysicalMaterial` for non-near LOD tiers.

## Changes

In `src/creatures/Amalgam.js`, replaced ternary expressions that evaluate to `undefined` with conditional spread syntax:

- **fleshMat** (line ~452): `normalScale: isNear ? new THREE.Vector2(0.6, 0.6) : undefined` → `...(isNear && { normalScale: new THREE.Vector2(0.6, 0.6) })`
- **boneMat** (line ~474): `normalScale: isNear ? new THREE.Vector2(0.5, 0.5) : undefined` → `...(isNear && { normalScale: new THREE.Vector2(0.5, 0.5) })`

When `isNear` is false, `normalScale` is now omitted entirely from the constructor options, so Three.js uses its default `(1,1)` without warning. When `isNear` is true, the same values are passed as before.

Fixes #174