### PR TITLE
fix: pass empty object to RAPIER.init() to silence deprecated API warning

### DIFF
--- a/src/physics/PhysicsWorld.js
+++ b/src/physics/PhysicsWorld.js
@@ -9,7 +9,7 @@ export class PhysicsWorld {
   }
 
   async init() {
-    await RAPIER.init();
+    await RAPIER.init({});
     // Zero gravity — the game handles movement via velocity + drag
     this.world = new RAPIER.World({ x: 0, y: 0, z: 0 });
 


### PR DESCRIPTION
## Summary

Fixes the only deprecation warning observed in the browser console during game initialization:

```
[warn] using deprecated parameters for the initialization function; pass a single object instead
```

Stack trace: `PhysicsWorld.js:12:18` → `RAPIER.init()`

## Investigation Results

Issue #175 was filed as "Three.js deprecated API warning" based on a single deprecation message observed during the Epic #161 play-test. The issue body explicitly states "Investigation needed" and lists Three.js causes as *possible* sources.

Runtime investigation using Chrome DevTools with `http://localhost:5173?autoplay` confirmed:

1. **The only deprecation warning in the console originates from `@dimforge/rapier3d-compat`** — specifically `RAPIER.init()` in `src/physics/PhysicsWorld.js`, which uses the deprecated no-argument calling convention. The Rapier 0.19.x wasm-bindgen init wrapper now expects a plain object argument.

2. **There are zero Three.js deprecated API warnings.** The codebase already uses the modern Three.js APIs:
   - `renderer.outputColorSpace` (not the deprecated `renderer.outputEncoding`)
   - `SRGBColorSpace` constant (not the deprecated `THREE.sRGBEncoding`)
   - No usage of deprecated `renderer.physicallyCorrectLights`
   - No deprecated `texture.encoding` usage

## Root Cause

In `src/physics/PhysicsWorld.js`, `RAPIER.init()` was called without arguments. The Rapier 0.19.x wasm-bindgen init wrapper now expects a plain object argument. Calling without arguments triggers the deprecation warning.

## Fix

Changed `await RAPIER.init()` to `await RAPIER.init({})` — passes an empty object which satisfies the new API signature while preserving the default WASM binary path behavior.

## Acceptance Criteria Fulfilled

Issue #175's acceptance criteria: "Zero Three.js deprecated API warnings in the browser console during normal play."

- ✅ Zero Three.js deprecated API warnings (confirmed — none exist in the codebase)
- ✅ Zero *any* deprecated API warnings after this fix (the Rapier warning was the only one)
- ✅ No visual or behavioral regressions

Fixes #175