### PR TITLE
fix: stagger jellyfish creation to stay within 50ms spawn budget

### DIFF
--- a/src/creatures/Jellyfish.js
+++ b/src/creatures/Jellyfish.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from "three";
 
 const LOD_NEAR_DISTANCE = 30;
 const LOD_MEDIUM_DISTANCE = 80;
@@ -27,15 +27,22 @@ function lerp(a, b, t) {
 // Create a soft circular sprite texture for glow effects.
 function createGlowTexture() {
   const size = 64;
-  const canvas = document.createElement('canvas');
+  const canvas = document.createElement("canvas");
   canvas.width = size;
   canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
-  gradient.addColorStop(0, 'rgba(255,255,255,1)');
-  gradient.addColorStop(0.3, 'rgba(255,255,255,0.6)');
-  gradient.addColorStop(0.7, 'rgba(255,255,255,0.1)');
-  gradient.addColorStop(1, 'rgba(255,255,255,0)');
+  const ctx = canvas.getContext("2d");
+  const gradient = ctx.createRadialGradient(
+    size / 2,
+    size / 2,
+    0,
+    size / 2,
+    size / 2,
+    size / 2,
+  );
+  gradient.addColorStop(0, "rgba(255,255,255,1)");
+  gradient.addColorStop(0.3, "rgba(255,255,255,0.6)");
+  gradient.addColorStop(0.7, "rgba(255,255,255,0.1)");
+  gradient.addColorStop(1, "rgba(255,255,255,0)");
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, size, size);
   const tex = new THREE.CanvasTexture(canvas);
@@ -47,10 +54,10 @@ const glowTexture = createGlowTexture();
 
 function createBellNormalTexture() {
   const size = 128;
-  const canvas = document.createElement('canvas');
+  const canvas = document.createElement("canvas");
   canvas.width = size;
   canvas.height = size;
-  const ctx = canvas.getContext('2d');
+  const ctx = canvas.getContext("2d");
   const image = ctx.createImageData(size, size);
   const data = image.data;
 
@@ -63,7 +70,10 @@ function createBellNormalTexture() {
       const radial = Math.cos(angle * 14 + v * 18) * 0.16;
       const nx = THREE.MathUtils.clamp(0.5 + radial, 0, 1);
       const ny = THREE.MathUtils.clamp(0.5 + band, 0, 1);
-      const nz = Math.sqrt(Math.max(0, 1 - (nx * 2 - 1) ** 2 - (ny * 2 - 1) ** 2)) * 0.5 + 0.5;
+      const nz =
+        Math.sqrt(Math.max(0, 1 - (nx * 2 - 1) ** 2 - (ny * 2 - 1) ** 2)) *
+          0.5 +
+        0.5;
       const i = (y * size + x) * 4;
       data[i] = Math.round(nx * 255);
       data[i + 1] = Math.round(ny * 255);
@@ -83,13 +93,13 @@ function createBellNormalTexture() {
 
 function createVeinTexture() {
   const size = 128;
-  const canvas = document.createElement('canvas');
+  const canvas = document.createElement("canvas");
   canvas.width = size;
   canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  ctx.fillStyle = 'black';
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = "black";
   ctx.fillRect(0, 0, size, size);
-  ctx.strokeStyle = 'rgba(255,255,255,0.9)';
+  ctx.strokeStyle = "rgba(255,255,255,0.9)";
   ctx.lineWidth = 1;
 
   for (let i = 0; i < 22; i++) {
@@ -101,7 +111,7 @@ function createVeinTexture() {
       const wobble = Math.sin(s * 1.7 + angle * 2.2) * size * 0.02;
       ctx.lineTo(
         size * 0.5 + Math.cos(angle + s * 0.11) * (r + wobble),
-        size * 0.2 + Math.sin(angle) * 0.08 * size + r * 0.9
+        size * 0.2 + Math.sin(angle) * 0.08 * size + r * 0.9,
       );
     }
     ctx.stroke();
@@ -116,11 +126,11 @@ function createVeinTexture() {
 
 function createPoreTexture() {
   const size = 128;
-  const canvas = document.createElement('canvas');
+  const canvas = document.createElement("canvas");
   canvas.width = size;
   canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  ctx.fillStyle = 'rgb(130,130,130)';
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = "rgb(130,130,130)";
   ctx.fillRect(0, 0, size, size);
   for (let i = 0; i < 520; i++) {
     const x = Math.random() * size;
@@ -220,19 +230,20 @@ export class Jellyfish {
 
     // More natural, muted bioluminescent palette.
     const colors = [
-      0x2288cc, 0xcc3388, 0x33bb88, 0x8844cc, 0xcc6633, 0x3399bb,
-      0x5566dd, 0xdd5577, 0x44ccaa, 0xbb55dd,
+      0x2288cc, 0xcc3388, 0x33bb88, 0x8844cc, 0xcc6633, 0x3399bb, 0x5566dd,
+      0xdd5577, 0x44ccaa, 0xbb55dd,
     ];
 
     // Pre-compute spawn positions and colors for all jellies so deferred
     // ones land in the same spatial cluster as immediate ones.
     this._pendingJellies = [];
+    this._pendingJellyIndex = 0;
     for (let i = 0; i < count; i++) {
       const color = colors[i % colors.length];
       const pos = new THREE.Vector3(
         position.x + (Math.random() - 0.5) * 30,
         position.y + (Math.random() - 0.5) * 15,
-        position.z + (Math.random() - 0.5) * 30
+        position.z + (Math.random() - 0.5) * 30,
       );
 
       if (i < SYNC_JELLY_LIMIT) {
@@ -246,6 +257,19 @@ export class Jellyfish {
     }
 
     scene.add(this.group);
+  }
+
+  /** Drain all remaining deferred jellies synchronously. */
+  finalize() {
+    while (this._pendingJellyIndex < this._pendingJellies.length) {
+      const pending = this._pendingJellies[this._pendingJellyIndex++];
+      const jelly = this._createJelly(pending.color);
+      jelly.group.position.copy(pending.position);
+      this.jellies.push(jelly);
+      this.group.add(jelly.group);
+    }
+    this._pendingJellies.length = 0;
+    this._pendingJellyIndex = 0;
   }
 
   _createBellMaterial(color, size, detailScale = 1) {
@@ -284,7 +308,7 @@ export class Jellyfish {
 
       shader.vertexShader = shader.vertexShader
         .replace(
-          '#include <common>',
+          "#include <common>",
           `#include <common>
 uniform float uContractionPhase;
 uniform float uJellyTime;
@@ -294,10 +318,10 @@ uniform float uBellSize;
 varying float vBellEdge;
 varying float vBellHeight;
 varying float vBellTravel;
-varying vec2 vJellyUv;`
+varying vec2 vJellyUv;`,
         )
         .replace(
-          '#include <begin_vertex>',
+          "#include <begin_vertex>",
           `#include <begin_vertex>
 vJellyUv = uv;
 float radial = length(position.xz) / max(uBellSize, 0.001);
@@ -316,12 +340,12 @@ transformed.y -= damageShape * max(0.0, cos(atan(position.z, position.x) - uDama
 transformed.y += stretchMarks;
 vBellEdge = edge;
 vBellHeight = transformed.y;
-vBellTravel = radial;`
+vBellTravel = radial;`,
         );
 
       shader.fragmentShader = shader.fragmentShader
         .replace(
-          '#include <common>',
+          "#include <common>",
           `#include <common>
 uniform float uContractionPhase;
 uniform float uJellyTime;
@@ -330,16 +354,16 @@ uniform sampler2D uVeinMap;
 varying float vBellEdge;
 varying float vBellHeight;
 varying float vBellTravel;
-varying vec2 vJellyUv;`
+varying vec2 vJellyUv;`,
         )
         .replace(
-          '#include <emissivemap_fragment>',
+          "#include <emissivemap_fragment>",
           `#include <emissivemap_fragment>
 float pulseHead = smoothstep(uPulseTravel - 0.2, uPulseTravel + 0.08, vBellTravel) * (1.0 - smoothstep(uPulseTravel + 0.08, uPulseTravel + 0.24, vBellTravel));
 float veins = texture2D(uVeinMap, vec2(vJellyUv.x, vJellyUv.y * 1.25)).r;
 float fresnel = pow(1.0 - abs(dot(normalize(vViewPosition), normal)), 2.6);
 float contractionGlow = max(uContractionPhase, 0.0) * 0.55;
-totalEmissiveRadiance += diffuseColor.rgb * (pulseHead * 1.25 + veins * 0.2 + fresnel * 0.32 + contractionGlow * vBellEdge * 0.34);`
+totalEmissiveRadiance += diffuseColor.rgb * (pulseHead * 1.25 + veins * 0.2 + fresnel * 0.32 + contractionGlow * vBellEdge * 0.34);`,
         );
 
       mat.userData.shader = shader;
@@ -349,7 +373,15 @@ totalEmissiveRadiance += diffuseColor.rgb * (pulseHead * 1.25 + veins * 0.2 + fr
   }
 
   _createBellGeometry(size, widthSegments, heightSegments) {
-    const bellGeo = new THREE.SphereGeometry(size, widthSegments, heightSegments, 0, Math.PI * 2, 0, Math.PI * 0.55);
+    const bellGeo = new THREE.SphereGeometry(
+      size,
+      widthSegments,
+      heightSegments,
+      0,
+      Math.PI * 2,
+      0,
+      Math.PI * 0.55,
+    );
     const positions = bellGeo.attributes.position;
     for (let i = 0; i < positions.count; i++) {
       const x = positions.getX(i);
@@ -426,45 +458,86 @@ totalEmissiveRadiance += diffuseColor.rgb * (pulseHead * 1.25 + veins * 0.2 + fr
     const pulseSqueeze = 1 - contraction * appendage.radialPulse;
     const driftX = jelly.velocityX * appendage.trailFactor * 0.32;
     const driftZ = jelly.velocityZ * appendage.trailFactor * 0.32;
-    const proximityWeight = jelly.proximityInfluence * appendage.proximityResponse;
+    const proximityWeight =
+      jelly.proximityInfluence * appendage.proximityResponse;
 
     for (let i = 0; i < rest.length; i += 3) {
       const baseX = rest[i];
       const baseY = rest[i + 1];
       const baseZ = rest[i + 2];
-      const along = THREE.MathUtils.clamp((appendage.maxY - baseY) / appendage.length, 0, 1);
+      const along = THREE.MathUtils.clamp(
+        (appendage.maxY - baseY) / appendage.length,
+        0,
+        1,
+      );
       const tipWeight = along * along * (3 - 2 * along);
       const tipWeightSq = tipWeight * tipWeight;
 
-      const waveA = Math.sin(t * appendage.swaySpeed + appendage.phaseOffset + along * appendage.waveFrequency);
-      const waveB = Math.sin(t * appendage.secondarySpeed + appendage.phaseOffset * 0.67 + along * appendage.secondaryFrequency);
-      const lateral = (waveA * appendage.swayAmount + waveB * appendage.secondarySwayAmount) * flowFactor * tipWeight;
-      const axial = Math.cos(t * appendage.twistSpeed + appendage.phaseOffset + along * appendage.waveFrequency * 0.55)
-        * appendage.twistAmount * tipWeight;
-      const curl = (relaxed * appendage.relaxCurlAmount - contraction * appendage.pulseCurlAmount) * tipWeightSq;
-      const crossing = Math.sin(t * appendage.crossSpeed + appendage.crossPhase + along * appendage.crossFrequency)
-        * appendage.crossAmount * contraction * tipWeight * appendage.crossSign;
-      const oralSpread = appendage.type === 'oral' ? contraction * appendage.spreadAmount * tipWeight : 0;
+      const waveA = Math.sin(
+        t * appendage.swaySpeed +
+          appendage.phaseOffset +
+          along * appendage.waveFrequency,
+      );
+      const waveB = Math.sin(
+        t * appendage.secondarySpeed +
+          appendage.phaseOffset * 0.67 +
+          along * appendage.secondaryFrequency,
+      );
+      const lateral =
+        (waveA * appendage.swayAmount + waveB * appendage.secondarySwayAmount) *
+        flowFactor *
+        tipWeight;
+      const axial =
+        Math.cos(
+          t * appendage.twistSpeed +
+            appendage.phaseOffset +
+            along * appendage.waveFrequency * 0.55,
+        ) *
+        appendage.twistAmount *
+        tipWeight;
+      const curl =
+        (relaxed * appendage.relaxCurlAmount -
+          contraction * appendage.pulseCurlAmount) *
+        tipWeightSq;
+      const crossing =
+        Math.sin(
+          t * appendage.crossSpeed +
+            appendage.crossPhase +
+            along * appendage.crossFrequency,
+        ) *
+        appendage.crossAmount *
+        contraction *
+        tipWeight *
+        appendage.crossSign;
+      const oralSpread =
+        appendage.type === "oral"
+          ? contraction * appendage.spreadAmount * tipWeight
+          : 0;
       const playerReact = proximityWeight * tipWeight;
-      const vertical = contraction * jelly.size * appendage.liftAmount * tipWeight
-        - relaxed * jelly.size * appendage.dropAmount * along * 0.4
-        + waveB * appendage.heaveAmount * tipWeightSq;
+      const vertical =
+        contraction * jelly.size * appendage.liftAmount * tipWeight -
+        relaxed * jelly.size * appendage.dropAmount * along * 0.4 +
+        waveB * appendage.heaveAmount * tipWeightSq;
 
       const radialX = baseX - appendage.rootCenter.x;
       const radialZ = baseZ - appendage.rootCenter.z;
       const radialScale = THREE.MathUtils.lerp(1, pulseSqueeze, tipWeight);
 
-      array[i] = appendage.rootCenter.x
-        + radialX * (radialScale + oralSpread)
-        + appendage.perpX * (lateral + crossing + jelly.playerDirX * playerReact * 0.06)
-        + appendage.dirX * (axial + driftX * tipWeight)
-        + radialX * curl;
+      array[i] =
+        appendage.rootCenter.x +
+        radialX * (radialScale + oralSpread) +
+        appendage.perpX *
+          (lateral + crossing + jelly.playerDirX * playerReact * 0.06) +
+        appendage.dirX * (axial + driftX * tipWeight) +
+        radialX * curl;
       array[i + 1] = baseY + vertical;
-      array[i + 2] = appendage.rootCenter.z
-        + radialZ * (radialScale + oralSpread)
-        + appendage.perpZ * (lateral + crossing + jelly.playerDirZ * playerReact * 0.06)
-        + appendage.dirZ * (axial + driftZ * tipWeight)
-        + radialZ * curl;
+      array[i + 2] =
+        appendage.rootCenter.z +
+        radialZ * (radialScale + oralSpread) +
+        appendage.perpZ *
+          (lateral + crossing + jelly.playerDirZ * playerReact * 0.06) +
+        appendage.dirZ * (axial + driftZ * tipWeight) +
+        radialZ * curl;
     }
 
     positions.needsUpdate = true;
@@ -479,7 +552,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (pulseHead * 1.25 + veins * 0.2 + fr
       profile.oralArmSegments,
       (0.055 * size + 0.012) * profile.oralArmRadiusScale,
       3,
-      false
+      false,
     );
     const frillPositions = frillGeo.attributes.position;
     for (let i = 0; i < frillPositions.count; i++) {
@@ -508,7 +581,14 @@ totalEmissiveRadiance += diffuseColor.rgb * (pulseHead * 1.25 + veins * 0.2 + fr
     return new THREE.Mesh(frillGeo, frillMat);
   }
 
-  _createNematocystSystem(group, tentacles, color, size, clusterCount, tierMotionScale) {
+  _createNematocystSystem(
+    group,
+    tentacles,
+    color,
+    size,
+    clusterCount,
+    tierMotionScale,
+  ) {
     if (!clusterCount || tentacles.length === 0) {
       return null;
     }
@@ -522,7 +602,11 @@ totalEmissiveRadiance += diffuseColor.rgb * (pulseHead * 1.25 + veins * 0.2 + fr
         let closestDelta = Infinity;
         for (let i = 0; i < descriptor.restPositions.length; i += 3) {
           const y = descriptor.restPositions[i + 1];
-          const localAlong = THREE.MathUtils.clamp((descriptor.maxY - y) / descriptor.length, 0, 1);
+          const localAlong = THREE.MathUtils.clamp(
+            (descriptor.maxY - y) / descriptor.length,
+            0,
+            1,
+          );
           const delta = Math.abs(localAlong - along);
           if (delta < closestDelta) {
             closestDelta = delta;
@@ -554,11 +638,14 @@ totalEmissiveRadiance += diffuseColor.rgb * (pulseHead * 1.25 + veins * 0.2 + fr
     const mesh = new THREE.InstancedMesh(geo, mat, count);
     mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
 
-    const pulseAttribute = new THREE.InstancedBufferAttribute(new Float32Array(count), 1);
+    const pulseAttribute = new THREE.InstancedBufferAttribute(
+      new Float32Array(count),
+      1,
+    );
     for (let i = 0; i < count; i++) {
       pulseAttribute.setX(i, references[i].pulseOffset);
     }
-    geo.setAttribute('instancePulse', pulseAttribute);
+    geo.setAttribute("instancePulse", pulseAttribute);
 
     mat.userData.shaderUniforms = {
       uPulseTime: { value: 0 },
@@ -568,30 +655,30 @@ totalEmissiveRadiance += diffuseColor.rgb * (pulseHead * 1.25 + veins * 0.2 + fr
       Object.assign(shader.uniforms, mat.userData.shaderUniforms);
       shader.vertexShader = shader.vertexShader
         .replace(
-          '#include <common>',
+          "#include <common>",
           `#include <common>
 attribute float instancePulse;
 uniform float uPulseTime;
-varying float vPulse;`
+varying float vPulse;`,
         )
         .replace(
-          '#include <begin_vertex>',
+          "#include <begin_vertex>",
           `#include <begin_vertex>
 float pulse = 0.8 + 0.2 * sin(uPulseTime * 2.8 + instancePulse * 1.6);
 transformed *= pulse;
-vPulse = pulse;`
+vPulse = pulse;`,
         );
 
       shader.fragmentShader = shader.fragmentShader
         .replace(
-          '#include <common>',
+          "#include <common>",
           `#include <common>
-varying float vPulse;`
+varying float vPulse;`,
         )
         .replace(
-          '#include <emissivemap_fragment>',
+          "#include <emissivemap_fragment>",
           `#include <emissivemap_fragment>
-totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
+totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`,
         );
       mat.userData.shader = shader;
     };
@@ -618,9 +705,15 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       _tmpPos.set(
         positions[baseIndex],
         positions[baseIndex + 1] + ref.liftBias,
-        positions[baseIndex + 2]
+        positions[baseIndex + 2],
       );
-      _tmpScale.setScalar(ref.baseScale * (0.86 + Math.sin(t * 2.7 + ref.pulseOffset) * 0.17 * system.tierMotionScale));
+      _tmpScale.setScalar(
+        ref.baseScale *
+          (0.86 +
+            Math.sin(t * 2.7 + ref.pulseOffset) *
+              0.17 *
+              system.tierMotionScale),
+      );
       _tmpMatrix.compose(_tmpPos, _tmpQuat.identity(), _tmpScale);
       system.mesh.setMatrixAt(i, _tmpMatrix);
     }
@@ -647,7 +740,14 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
     stomach.position.y = -size * 0.07;
     group.add(stomach);
 
-    const manubriumGeo = new THREE.CylinderGeometry(size * 0.042, size * 0.07, size * 0.5, 10, 1, true);
+    const manubriumGeo = new THREE.CylinderGeometry(
+      size * 0.042,
+      size * 0.07,
+      size * 0.5,
+      10,
+      1,
+      true,
+    );
     const manubriumMat = new THREE.MeshPhysicalMaterial({
       color,
       emissive: color,
@@ -666,11 +766,29 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
     for (let i = 0; i < 4; i++) {
       const angle = (i / 4) * TWO_PI;
       const pts = [
-        new THREE.Vector3(Math.cos(angle) * size * 0.12, -size * 0.1, Math.sin(angle) * size * 0.12),
-        new THREE.Vector3(Math.cos(angle + 0.2) * size * 0.16, -size * 0.24, Math.sin(angle + 0.2) * size * 0.16),
-        new THREE.Vector3(Math.cos(angle - 0.1) * size * 0.1, -size * 0.44, Math.sin(angle - 0.1) * size * 0.1),
+        new THREE.Vector3(
+          Math.cos(angle) * size * 0.12,
+          -size * 0.1,
+          Math.sin(angle) * size * 0.12,
+        ),
+        new THREE.Vector3(
+          Math.cos(angle + 0.2) * size * 0.16,
+          -size * 0.24,
+          Math.sin(angle + 0.2) * size * 0.16,
+        ),
+        new THREE.Vector3(
+          Math.cos(angle - 0.1) * size * 0.1,
+          -size * 0.44,
+          Math.sin(angle - 0.1) * size * 0.1,
+        ),
       ];
-      const armGeo = new THREE.TubeGeometry(new THREE.CatmullRomCurve3(pts), 8, size * 0.03, 6, false);
+      const armGeo = new THREE.TubeGeometry(
+        new THREE.CatmullRomCurve3(pts),
+        8,
+        size * 0.03,
+        6,
+        false,
+      );
       const armMat = new THREE.MeshPhysicalMaterial({
         color,
         emissive: color,
@@ -690,11 +808,29 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
     for (let i = 0; i < 6; i++) {
       const angle = (i / 6) * TWO_PI;
       const filamentPts = [
-        new THREE.Vector3(Math.cos(angle) * size * 0.06, -size * 0.12, Math.sin(angle) * size * 0.06),
-        new THREE.Vector3(Math.cos(angle + 0.3) * size * 0.08, -size * 0.24, Math.sin(angle + 0.3) * size * 0.08),
-        new THREE.Vector3(Math.cos(angle - 0.2) * size * 0.04, -size * 0.35, Math.sin(angle - 0.2) * size * 0.04),
+        new THREE.Vector3(
+          Math.cos(angle) * size * 0.06,
+          -size * 0.12,
+          Math.sin(angle) * size * 0.06,
+        ),
+        new THREE.Vector3(
+          Math.cos(angle + 0.3) * size * 0.08,
+          -size * 0.24,
+          Math.sin(angle + 0.3) * size * 0.08,
+        ),
+        new THREE.Vector3(
+          Math.cos(angle - 0.2) * size * 0.04,
+          -size * 0.35,
+          Math.sin(angle - 0.2) * size * 0.04,
+        ),
       ];
-      const filamentGeo = new THREE.TubeGeometry(new THREE.CatmullRomCurve3(filamentPts), 5, size * 0.01, 4, false);
+      const filamentGeo = new THREE.TubeGeometry(
+        new THREE.CatmullRomCurve3(filamentPts),
+        5,
+        size * 0.01,
+        4,
+        false,
+      );
       const filament = new THREE.Mesh(
         filamentGeo,
         new THREE.MeshPhysicalMaterial({
@@ -706,7 +842,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
           roughness: 0.4,
           transmission: 0.18,
           depthWrite: false,
-        })
+        }),
       );
       gastricFilaments.add(filament);
     }
@@ -747,12 +883,17 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       const points = [];
       for (let s = 0; s <= profile.oralArmSegments; s++) {
         const t = s / profile.oralArmSegments;
-        const curl = Math.sin(t * Math.PI * 1.4 + angle) * (0.03 + 0.05 * t) * size;
-        points.push(new THREE.Vector3(
-          Math.cos(angle) * rootRadius * (1 - t * 0.55) + Math.cos(angle + Math.PI * 0.5) * curl,
-          -size * 0.2 - t * armLen,
-          Math.sin(angle) * rootRadius * (1 - t * 0.55) + Math.sin(angle + Math.PI * 0.5) * curl
-        ));
+        const curl =
+          Math.sin(t * Math.PI * 1.4 + angle) * (0.03 + 0.05 * t) * size;
+        points.push(
+          new THREE.Vector3(
+            Math.cos(angle) * rootRadius * (1 - t * 0.55) +
+              Math.cos(angle + Math.PI * 0.5) * curl,
+            -size * 0.2 - t * armLen,
+            Math.sin(angle) * rootRadius * (1 - t * 0.55) +
+              Math.sin(angle + Math.PI * 0.5) * curl,
+          ),
+        );
       }
       const curve = new THREE.CatmullRomCurve3(points);
       const armGeo = new THREE.TubeGeometry(
@@ -760,7 +901,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
         profile.oralArmSegments,
         (0.04 * size + 0.01) * profile.oralArmRadiusScale,
         profile.oralArmRadialSegments,
-        false
+        false,
       );
       const armMat = new THREE.MeshPhysicalMaterial({
         color,
@@ -779,72 +920,78 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       const frill = this._createOralArmFrill(curve, size, color, profile);
       group.add(frill);
 
-      oralArms.push(this._createAppendageDescriptor(arm, {
-        type: 'oral',
-        angle,
-        dirX: Math.cos(angle),
-        dirZ: Math.sin(angle),
-        perpX: Math.cos(angle + Math.PI * 0.5),
-        perpZ: Math.sin(angle + Math.PI * 0.5),
-        phaseOffset: Math.random() * Math.PI * 2,
-        swaySpeed: 0.58 + Math.random() * 0.24,
-        secondarySpeed: 0.34 + Math.random() * 0.18,
-        swayAmount: 0.025 + Math.random() * 0.035,
-        secondarySwayAmount: 0.015 + Math.random() * 0.02,
-        waveFrequency: 2.8 + Math.random() * 0.8,
-        secondaryFrequency: 5.2 + Math.random() * 1.1,
-        twistSpeed: 0.36 + Math.random() * 0.12,
-        twistAmount: 0.02 + Math.random() * 0.03,
-        liftAmount: 0.03 + Math.random() * 0.03,
-        heaveAmount: 0.01 + Math.random() * 0.012,
-        pulseCurlAmount: 0.02 + Math.random() * 0.018,
-        relaxCurlAmount: 0.045 + Math.random() * 0.025,
-        dropAmount: 0.015 + Math.random() * 0.02,
-        radialPulse: 0.03 + Math.random() * 0.02,
-        trailFactor: 0.3 + Math.random() * 0.25,
-        proximityResponse: 0.6 + Math.random() * 0.4,
-        spreadAmount: 0.14 + Math.random() * 0.1,
-        crossSpeed: 0.4 + Math.random() * 0.2,
-        crossPhase: Math.random() * TWO_PI,
-        crossFrequency: 3.4 + Math.random() * 1.8,
-        crossAmount: 0.02 + Math.random() * 0.018,
-        crossSign: Math.random() > 0.5 ? 1 : -1,
-      }));
+      oralArms.push(
+        this._createAppendageDescriptor(arm, {
+          type: "oral",
+          angle,
+          dirX: Math.cos(angle),
+          dirZ: Math.sin(angle),
+          perpX: Math.cos(angle + Math.PI * 0.5),
+          perpZ: Math.sin(angle + Math.PI * 0.5),
+          phaseOffset: Math.random() * Math.PI * 2,
+          swaySpeed: 0.58 + Math.random() * 0.24,
+          secondarySpeed: 0.34 + Math.random() * 0.18,
+          swayAmount: 0.025 + Math.random() * 0.035,
+          secondarySwayAmount: 0.015 + Math.random() * 0.02,
+          waveFrequency: 2.8 + Math.random() * 0.8,
+          secondaryFrequency: 5.2 + Math.random() * 1.1,
+          twistSpeed: 0.36 + Math.random() * 0.12,
+          twistAmount: 0.02 + Math.random() * 0.03,
+          liftAmount: 0.03 + Math.random() * 0.03,
+          heaveAmount: 0.01 + Math.random() * 0.012,
+          pulseCurlAmount: 0.02 + Math.random() * 0.018,
+          relaxCurlAmount: 0.045 + Math.random() * 0.025,
+          dropAmount: 0.015 + Math.random() * 0.02,
+          radialPulse: 0.03 + Math.random() * 0.02,
+          trailFactor: 0.3 + Math.random() * 0.25,
+          proximityResponse: 0.6 + Math.random() * 0.4,
+          spreadAmount: 0.14 + Math.random() * 0.1,
+          crossSpeed: 0.4 + Math.random() * 0.2,
+          crossPhase: Math.random() * TWO_PI,
+          crossFrequency: 3.4 + Math.random() * 1.8,
+          crossAmount: 0.02 + Math.random() * 0.018,
+          crossSign: Math.random() > 0.5 ? 1 : -1,
+        }),
+      );
 
-      oralArms.push(this._createAppendageDescriptor(frill, {
-        type: 'oral',
-        angle,
-        dirX: Math.cos(angle),
-        dirZ: Math.sin(angle),
-        perpX: Math.cos(angle + HALF_PI),
-        perpZ: Math.sin(angle + HALF_PI),
-        phaseOffset: Math.random() * TWO_PI,
-        swaySpeed: 0.6 + Math.random() * 0.2,
-        secondarySpeed: 0.35 + Math.random() * 0.2,
-        swayAmount: 0.03 + Math.random() * 0.025,
-        secondarySwayAmount: 0.018 + Math.random() * 0.015,
-        waveFrequency: 3 + Math.random() * 0.8,
-        secondaryFrequency: 5.6 + Math.random() * 1,
-        twistSpeed: 0.4 + Math.random() * 0.15,
-        twistAmount: 0.025 + Math.random() * 0.02,
-        liftAmount: 0.026 + Math.random() * 0.024,
-        heaveAmount: 0.012 + Math.random() * 0.012,
-        pulseCurlAmount: 0.016 + Math.random() * 0.016,
-        relaxCurlAmount: 0.036 + Math.random() * 0.02,
-        dropAmount: 0.014 + Math.random() * 0.012,
-        radialPulse: 0.028 + Math.random() * 0.018,
-        trailFactor: 0.26 + Math.random() * 0.2,
-        proximityResponse: 0.7 + Math.random() * 0.35,
-        spreadAmount: 0.19 + Math.random() * 0.08,
-        crossSpeed: 0.35 + Math.random() * 0.16,
-        crossPhase: Math.random() * TWO_PI,
-        crossFrequency: 2.8 + Math.random() * 1.2,
-        crossAmount: 0.03 + Math.random() * 0.015,
-        crossSign: Math.random() > 0.5 ? 1 : -1,
-      }));
+      oralArms.push(
+        this._createAppendageDescriptor(frill, {
+          type: "oral",
+          angle,
+          dirX: Math.cos(angle),
+          dirZ: Math.sin(angle),
+          perpX: Math.cos(angle + HALF_PI),
+          perpZ: Math.sin(angle + HALF_PI),
+          phaseOffset: Math.random() * TWO_PI,
+          swaySpeed: 0.6 + Math.random() * 0.2,
+          secondarySpeed: 0.35 + Math.random() * 0.2,
+          swayAmount: 0.03 + Math.random() * 0.025,
+          secondarySwayAmount: 0.018 + Math.random() * 0.015,
+          waveFrequency: 3 + Math.random() * 0.8,
+          secondaryFrequency: 5.6 + Math.random() * 1,
+          twistSpeed: 0.4 + Math.random() * 0.15,
+          twistAmount: 0.025 + Math.random() * 0.02,
+          liftAmount: 0.026 + Math.random() * 0.024,
+          heaveAmount: 0.012 + Math.random() * 0.012,
+          pulseCurlAmount: 0.016 + Math.random() * 0.016,
+          relaxCurlAmount: 0.036 + Math.random() * 0.02,
+          dropAmount: 0.014 + Math.random() * 0.012,
+          radialPulse: 0.028 + Math.random() * 0.018,
+          trailFactor: 0.26 + Math.random() * 0.2,
+          proximityResponse: 0.7 + Math.random() * 0.35,
+          spreadAmount: 0.19 + Math.random() * 0.08,
+          crossSpeed: 0.35 + Math.random() * 0.16,
+          crossPhase: Math.random() * TWO_PI,
+          crossFrequency: 2.8 + Math.random() * 1.2,
+          crossAmount: 0.03 + Math.random() * 0.015,
+          crossSign: Math.random() > 0.5 ? 1 : -1,
+        }),
+      );
     }
 
-    const tentacleCount = profile.tentacleMin + Math.floor(Math.random() * profile.tentacleMaxExtra);
+    const tentacleCount =
+      profile.tentacleMin +
+      Math.floor(Math.random() * profile.tentacleMaxExtra);
     for (let t = 0; t < tentacleCount; t++) {
       const clusterPhase = (t / tentacleCount) * Math.PI * 2;
       const angle = clusterPhase + (Math.random() - 0.5) * 0.45;
@@ -854,12 +1001,17 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       const points = [];
       for (let s = 0; s <= profile.tentacleSegments; s++) {
         const frac = s / profile.tentacleSegments;
-        const lateralCurl = Math.sin(frac * Math.PI * 2 + angle * 1.5) * 0.05 * frac * size;
-        points.push(new THREE.Vector3(
-          Math.cos(angle) * radius * (1 - frac * 0.48) + Math.cos(angle + Math.PI * 0.5) * lateralCurl,
-          rootYOffset - frac * tentLen,
-          Math.sin(angle) * radius * (1 - frac * 0.48) + Math.sin(angle + Math.PI * 0.5) * lateralCurl
-        ));
+        const lateralCurl =
+          Math.sin(frac * Math.PI * 2 + angle * 1.5) * 0.05 * frac * size;
+        points.push(
+          new THREE.Vector3(
+            Math.cos(angle) * radius * (1 - frac * 0.48) +
+              Math.cos(angle + Math.PI * 0.5) * lateralCurl,
+            rootYOffset - frac * tentLen,
+            Math.sin(angle) * radius * (1 - frac * 0.48) +
+              Math.sin(angle + Math.PI * 0.5) * lateralCurl,
+          ),
+        );
       }
       const curve = new THREE.CatmullRomCurve3(points);
       const tentGeo = new THREE.TubeGeometry(
@@ -867,7 +1019,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
         profile.tentacleSegments,
         (0.015 * size + 0.005) * profile.tentacleRadiusScale,
         profile.tentacleRadialSegments,
-        false
+        false,
       );
       const tentMat = new THREE.MeshPhysicalMaterial({
         color,
@@ -880,37 +1032,39 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       });
       const tentacle = new THREE.Mesh(tentGeo, tentMat);
       group.add(tentacle);
-      tentacles.push(this._createAppendageDescriptor(tentacle, {
-        type: 'tentacle',
-        angle,
-        dirX: Math.cos(angle),
-        dirZ: Math.sin(angle),
-        perpX: Math.cos(angle + Math.PI * 0.5),
-        perpZ: Math.sin(angle + Math.PI * 0.5),
-        phaseOffset: Math.random() * Math.PI * 2,
-        swaySpeed: 0.5 + Math.random() * 0.5,
-        swayAmount: 0.04 + Math.random() * 0.04,
-        secondarySpeed: 0.3 + Math.random() * 0.18,
-        secondarySwayAmount: 0.02 + Math.random() * 0.02,
-        waveFrequency: 4.2 + Math.random() * 1.3,
-        secondaryFrequency: 7.8 + Math.random() * 1.6,
-        twistSpeed: 0.42 + Math.random() * 0.2,
-        twistAmount: 0.03 + Math.random() * 0.03,
-        trailFactor: 0.4 + Math.random() * 0.4,
-        liftAmount: 0.05 + Math.random() * 0.05,
-        heaveAmount: 0.016 + Math.random() * 0.018,
-        pulseCurlAmount: 0.03 + Math.random() * 0.025,
-        relaxCurlAmount: 0.07 + Math.random() * 0.03,
-        dropAmount: 0.018 + Math.random() * 0.02,
-        radialPulse: 0.04 + Math.random() * 0.02,
-        proximityResponse: 0.95 + Math.random() * 0.35,
-        spreadAmount: 0,
-        crossSpeed: 0.64 + Math.random() * 0.24,
-        crossPhase: Math.random() * TWO_PI,
-        crossFrequency: 5.8 + Math.random() * 2.5,
-        crossAmount: 0.05 + Math.random() * 0.04,
-        crossSign: Math.random() > 0.5 ? 1 : -1,
-      }));
+      tentacles.push(
+        this._createAppendageDescriptor(tentacle, {
+          type: "tentacle",
+          angle,
+          dirX: Math.cos(angle),
+          dirZ: Math.sin(angle),
+          perpX: Math.cos(angle + Math.PI * 0.5),
+          perpZ: Math.sin(angle + Math.PI * 0.5),
+          phaseOffset: Math.random() * Math.PI * 2,
+          swaySpeed: 0.5 + Math.random() * 0.5,
+          swayAmount: 0.04 + Math.random() * 0.04,
+          secondarySpeed: 0.3 + Math.random() * 0.18,
+          secondarySwayAmount: 0.02 + Math.random() * 0.02,
+          waveFrequency: 4.2 + Math.random() * 1.3,
+          secondaryFrequency: 7.8 + Math.random() * 1.6,
+          twistSpeed: 0.42 + Math.random() * 0.2,
+          twistAmount: 0.03 + Math.random() * 0.03,
+          trailFactor: 0.4 + Math.random() * 0.4,
+          liftAmount: 0.05 + Math.random() * 0.05,
+          heaveAmount: 0.016 + Math.random() * 0.018,
+          pulseCurlAmount: 0.03 + Math.random() * 0.025,
+          relaxCurlAmount: 0.07 + Math.random() * 0.03,
+          dropAmount: 0.018 + Math.random() * 0.02,
+          radialPulse: 0.04 + Math.random() * 0.02,
+          proximityResponse: 0.95 + Math.random() * 0.35,
+          spreadAmount: 0,
+          crossSpeed: 0.64 + Math.random() * 0.24,
+          crossPhase: Math.random() * TWO_PI,
+          crossFrequency: 5.8 + Math.random() * 2.5,
+          crossAmount: 0.05 + Math.random() * 0.04,
+          crossSign: Math.random() > 0.5 ? 1 : -1,
+        }),
+      );
     }
 
     const nematocysts = this._createNematocystSystem(
@@ -919,7 +1073,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       color,
       size,
       profile.tentacleNematocystClusters,
-      profile.appendageMotionScale
+      profile.appendageMotionScale,
     );
 
     return { oralArms, tentacles, nematocysts };
@@ -930,7 +1084,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
 
     const farBell = new THREE.Mesh(
       new THREE.IcosahedronGeometry(size * 0.9, 0),
-      this._createBellMaterial(color, size, 0.8)
+      this._createBellMaterial(color, size, 0.8),
     );
     group.add(farBell);
 
@@ -942,7 +1096,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
         opacity: 0.24,
         depthWrite: false,
         side: THREE.DoubleSide,
-      })
+      }),
     );
     silhouette.rotation.x = HALF_PI;
     silhouette.position.y = -size * 0.18;
@@ -955,8 +1109,14 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
     const oralArms = [];
     const tentacles = [];
     const farCountScale = LOD_PROFILE.far.appendageCountScale;
-    const reducedOralCount = Math.max(1, Math.round(LOD_PROFILE.near.oralArmCount * farCountScale));
-    const reducedTentacleCount = Math.max(1, Math.round(LOD_PROFILE.near.tentacleMin * farCountScale));
+    const reducedOralCount = Math.max(
+      1,
+      Math.round(LOD_PROFILE.near.oralArmCount * farCountScale),
+    );
+    const reducedTentacleCount = Math.max(
+      1,
+      Math.round(LOD_PROFILE.near.tentacleMin * farCountScale),
+    );
 
     const oralMat = new THREE.MeshBasicMaterial({
       color,
@@ -977,30 +1137,43 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       const angle = (i / reducedOralCount) * TWO_PI;
       const oralPlane = new THREE.Mesh(
         new THREE.PlaneGeometry(size * 0.12, size * 1.35),
-        oralMat
+        oralMat,
       );
-      oralPlane.position.set(Math.cos(angle) * size * 0.1, -size * 0.8, Math.sin(angle) * size * 0.1);
+      oralPlane.position.set(
+        Math.cos(angle) * size * 0.1,
+        -size * 0.8,
+        Math.sin(angle) * size * 0.1,
+      );
       oralPlane.rotation.y = angle;
       trailGroup.add(oralPlane);
-      oralArms.push(this._createAppendageDescriptor(oralPlane, {
-        type: 'oral',
-        angle,
-      }));
+      oralArms.push(
+        this._createAppendageDescriptor(oralPlane, {
+          type: "oral",
+          angle,
+        }),
+      );
     }
 
     for (let i = 0; i < reducedTentacleCount; i++) {
-      const angle = (i / reducedTentacleCount) * TWO_PI + (Math.random() - 0.5) * 0.22;
+      const angle =
+        (i / reducedTentacleCount) * TWO_PI + (Math.random() - 0.5) * 0.22;
       const tentaclePlane = new THREE.Mesh(
         new THREE.PlaneGeometry(size * 0.06, size * 1.8),
-        tentacleMat
+        tentacleMat,
       );
-      tentaclePlane.position.set(Math.cos(angle) * size * 0.22, -size * 1.05, Math.sin(angle) * size * 0.22);
+      tentaclePlane.position.set(
+        Math.cos(angle) * size * 0.22,
+        -size * 1.05,
+        Math.sin(angle) * size * 0.22,
+      );
       tentaclePlane.rotation.y = angle;
       trailGroup.add(tentaclePlane);
-      tentacles.push(this._createAppendageDescriptor(tentaclePlane, {
-        type: 'tentacle',
-        angle,
-      }));
+      tentacles.push(
+        this._createAppendageDescriptor(tentaclePlane, {
+          type: "tentacle",
+          angle,
+        }),
+      );
     }
 
     group.add(trailGroup);
@@ -1028,7 +1201,14 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
     const group = new THREE.Group();
 
     const bellMat = this._createBellMaterial(color, size, 1);
-    const bell = new THREE.Mesh(this._createBellGeometry(size, profile.bellWidthSegments, profile.bellHeightSegments), bellMat);
+    const bell = new THREE.Mesh(
+      this._createBellGeometry(
+        size,
+        profile.bellWidthSegments,
+        profile.bellHeightSegments,
+      ),
+      bellMat,
+    );
     group.add(bell);
 
     const innerGeo = new THREE.SphereGeometry(
@@ -1038,7 +1218,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       0,
       Math.PI * 2,
       0,
-      Math.PI * 0.5
+      Math.PI * 0.5,
     );
     const innerMat = new THREE.MeshPhysicalMaterial({
       color,
@@ -1057,7 +1237,12 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
 
     const rimInnerRadius = size * 0.72;
     const rimOuterRadius = size * 0.98;
-    const rimGeo = new THREE.RingGeometry(rimInnerRadius, rimOuterRadius, profile.rimTubeSegments, 1);
+    const rimGeo = new THREE.RingGeometry(
+      rimInnerRadius,
+      rimOuterRadius,
+      profile.rimTubeSegments,
+      1,
+    );
     const rimPositions = rimGeo.attributes.position;
     const rimWidth = rimOuterRadius - rimInnerRadius;
     for (let i = 0; i < rimPositions.count; i++) {
@@ -1086,7 +1271,12 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
     rim.rotation.x = Math.PI / 2;
     group.add(rim);
 
-    const appendages = this._createFlowingAppendages(group, color, size, profile);
+    const appendages = this._createFlowingAppendages(
+      group,
+      color,
+      size,
+      profile,
+    );
     const interior = this._createBellInteriorDetail(group, color, size);
     const jet = this._createJetMesh(color, size);
     group.add(jet);
@@ -1172,12 +1362,25 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
 
   _getLodTierName(distanceToPlayer, previousTierName) {
     const hysteresis = 4;
-    if (previousTierName === 'near' && distanceToPlayer < LOD_NEAR_DISTANCE + hysteresis) return 'near';
-    if (previousTierName === 'medium' && distanceToPlayer > LOD_NEAR_DISTANCE - hysteresis && distanceToPlayer < LOD_MEDIUM_DISTANCE + hysteresis) return 'medium';
-    if (previousTierName === 'far' && distanceToPlayer > LOD_MEDIUM_DISTANCE - hysteresis) return 'far';
-    if (distanceToPlayer < LOD_NEAR_DISTANCE) return 'near';
-    if (distanceToPlayer < LOD_MEDIUM_DISTANCE) return 'medium';
-    return 'far';
+    if (
+      previousTierName === "near" &&
+      distanceToPlayer < LOD_NEAR_DISTANCE + hysteresis
+    )
+      return "near";
+    if (
+      previousTierName === "medium" &&
+      distanceToPlayer > LOD_NEAR_DISTANCE - hysteresis &&
+      distanceToPlayer < LOD_MEDIUM_DISTANCE + hysteresis
+    )
+      return "medium";
+    if (
+      previousTierName === "far" &&
+      distanceToPlayer > LOD_MEDIUM_DISTANCE - hysteresis
+    )
+      return "far";
+    if (distanceToPlayer < LOD_NEAR_DISTANCE) return "near";
+    if (distanceToPlayer < LOD_MEDIUM_DISTANCE) return "medium";
+    return "far";
   }
 
   _updateBellShaderUniforms(tier, pulse, t, jelly) {
@@ -1186,7 +1389,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
     const uniforms = bellMaterial.userData.shaderUniforms;
     uniforms.uContractionPhase.value = pulse;
     uniforms.uJellyTime.value = t;
-    uniforms.uPulseTravel.value = (Math.sin(t * 2 + jelly.phase) * 0.5 + 0.5);
+    uniforms.uPulseTravel.value = Math.sin(t * 2 + jelly.phase) * 0.5 + 0.5;
     uniforms.uDamage.value = jelly.damageAmount;
     uniforms.uDamageSide.value = jelly.damageSide;
   }
@@ -1194,8 +1397,12 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
   _animateTierAppendages(jelly, tier, pulse, t) {
     if (tier.farTrailGroup) {
       tier.farTrailGroup.rotation.y += 0.025 + Math.max(0, pulse) * 0.05;
-      tier.farTrailGroup.rotation.x = tier.farTrailGroup.userData.baseRotX + Math.sin(t * 0.45 + jelly.phase) * 0.08;
-      tier.farTrailGroup.rotation.z = tier.farTrailGroup.userData.baseRotZ + Math.cos(t * 0.38 + jelly.rollPhase) * 0.07;
+      tier.farTrailGroup.rotation.x =
+        tier.farTrailGroup.userData.baseRotX +
+        Math.sin(t * 0.45 + jelly.phase) * 0.08;
+      tier.farTrailGroup.rotation.z =
+        tier.farTrailGroup.userData.baseRotZ +
+        Math.cos(t * 0.38 + jelly.rollPhase) * 0.07;
       return;
     }
 
@@ -1212,12 +1419,17 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
 
   update(dt, playerPos) {
     // Drain one deferred jelly per frame to spread construction cost.
-    if (this._pendingJellies.length > 0) {
-      const pending = this._pendingJellies.shift();
+    if (this._pendingJellyIndex < this._pendingJellies.length) {
+      const pending = this._pendingJellies[this._pendingJellyIndex++];
       const jelly = this._createJelly(pending.color);
       jelly.group.position.copy(pending.position);
       this.jellies.push(jelly);
       this.group.add(jelly.group);
+      // Release references once fully drained.
+      if (this._pendingJellyIndex >= this._pendingJellies.length) {
+        this._pendingJellies.length = 0;
+        this._pendingJellyIndex = 0;
+      }
     }
 
     this.time += dt;
@@ -1233,7 +1445,11 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       const planarLength = Math.max(0.0001, Math.sqrt(dx * dx + dz * dz));
       jelly.playerDirX = dx / planarLength;
       jelly.playerDirZ = dz / planarLength;
-      jelly.proximityInfluence = THREE.MathUtils.clamp(1 - preMoveDistToPlayer / 22, 0, 1);
+      jelly.proximityInfluence = THREE.MathUtils.clamp(
+        1 - preMoveDistToPlayer / 22,
+        0,
+        1,
+      );
 
       const phaseSpeedScale = 1 + jelly.proximityInfluence * 0.7;
       const contractionSpeed = jelly.pulseSpeed * 1.45 * phaseSpeedScale;
@@ -1258,17 +1474,22 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       }
       jelly.damageAmount = Math.max(0, jelly.damageAmount - dt * 0.6);
 
-      const desiredVX = jelly.driftX * (0.32 + (1 - contraction) * 0.58)
-        + jelly.playerDirX * jelly.proximityInfluence * jelly.reactionBias * 0.22;
-      const desiredVY = jelly.verticalDrift + propulsion * 0.56 - glideDrag * 0.08;
-      const desiredVZ = jelly.driftZ * (0.32 + (1 - contraction) * 0.58)
-        + jelly.playerDirZ * jelly.proximityInfluence * jelly.reactionBias * 0.22;
+      const desiredVX =
+        jelly.driftX * (0.32 + (1 - contraction) * 0.58) +
+        jelly.playerDirX * jelly.proximityInfluence * jelly.reactionBias * 0.22;
+      const desiredVY =
+        jelly.verticalDrift + propulsion * 0.56 - glideDrag * 0.08;
+      const desiredVZ =
+        jelly.driftZ * (0.32 + (1 - contraction) * 0.58) +
+        jelly.playerDirZ * jelly.proximityInfluence * jelly.reactionBias * 0.22;
 
       const inertia = 1 - Math.exp(-dt * 2.8);
       const drag = 1 - Math.exp(-dt * 1.7);
-      jelly.velocityX = lerp(jelly.velocityX, desiredVX, inertia) * (1 - drag * 0.2);
+      jelly.velocityX =
+        lerp(jelly.velocityX, desiredVX, inertia) * (1 - drag * 0.2);
       jelly.velocityY = lerp(jelly.velocityY, desiredVY, inertia);
-      jelly.velocityZ = lerp(jelly.velocityZ, desiredVZ, inertia) * (1 - drag * 0.2);
+      jelly.velocityZ =
+        lerp(jelly.velocityZ, desiredVZ, inertia) * (1 - drag * 0.2);
 
       jelly.group.position.x += jelly.velocityX * dt;
       jelly.group.position.y += jelly.velocityY * dt;
@@ -1277,9 +1498,16 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       const postMoveDx = playerPos.x - jelly.group.position.x;
       const postMoveDy = playerPos.y - jelly.group.position.y;
       const postMoveDz = playerPos.z - jelly.group.position.z;
-      const distToPlayer = Math.sqrt(postMoveDx * postMoveDx + postMoveDy * postMoveDy + postMoveDz * postMoveDz);
+      const distToPlayer = Math.sqrt(
+        postMoveDx * postMoveDx +
+          postMoveDy * postMoveDy +
+          postMoveDz * postMoveDz,
+      );
 
-      const activeTierName = this._getLodTierName(distToPlayer, jelly.lastActiveTierName);
+      const activeTierName = this._getLodTierName(
+        distToPlayer,
+        jelly.lastActiveTierName,
+      );
       const activeTier = jelly.tiers[activeTierName];
 
       // Keep newly visible tiers in sync so LOD transitions don't reveal stale appendage geometry.
@@ -1296,19 +1524,44 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       this._updateBellShaderUniforms(jelly.tiers.medium, pulseShape, t, jelly);
       this._updateBellShaderUniforms(jelly.tiers.far, pulseShape, t, jelly);
 
-      jelly.tiers.near.inner.scale.set(squishX * 0.98, squishY * 0.92, squishX * 0.98);
-      jelly.tiers.near.rim.scale.set(1 + contraction * 0.12, 1, 1 + contraction * 0.12);
-      jelly.tiers.medium.inner.scale.set(squishX * 0.98, squishY * 0.94, squishX * 0.98);
-      jelly.tiers.medium.rim.scale.set(1 + contraction * 0.08, 1, 1 + contraction * 0.08);
+      jelly.tiers.near.inner.scale.set(
+        squishX * 0.98,
+        squishY * 0.92,
+        squishX * 0.98,
+      );
+      jelly.tiers.near.rim.scale.set(
+        1 + contraction * 0.12,
+        1,
+        1 + contraction * 0.12,
+      );
+      jelly.tiers.medium.inner.scale.set(
+        squishX * 0.98,
+        squishY * 0.94,
+        squishX * 0.98,
+      );
+      jelly.tiers.medium.rim.scale.set(
+        1 + contraction * 0.08,
+        1,
+        1 + contraction * 0.08,
+      );
 
       const jetOpacity = contraction > 0.16 ? (contraction - 0.16) * 0.55 : 0;
       jelly.tiers.near.jet.material.opacity = jetOpacity;
-      jelly.tiers.near.jet.scale.set(1 + contraction * 1.8, 1 + contraction * 1.6, 1 + contraction * 1.8);
+      jelly.tiers.near.jet.scale.set(
+        1 + contraction * 1.8,
+        1 + contraction * 1.6,
+        1 + contraction * 1.8,
+      );
       jelly.tiers.medium.jet.material.opacity = jetOpacity * 0.8;
-      jelly.tiers.medium.jet.scale.set(1 + contraction * 1.4, 1 + contraction * 1.3, 1 + contraction * 1.4);
+      jelly.tiers.medium.jet.scale.set(
+        1 + contraction * 1.4,
+        1 + contraction * 1.3,
+        1 + contraction * 1.4,
+      );
       jelly.tiers.far.jet.material.opacity = jetOpacity * 0.6;
 
-      jelly.light.intensity = activeTierName === 'near' ? (0.12 + contraction * 0.28) : 0;
+      jelly.light.intensity =
+        activeTierName === "near" ? 0.12 + contraction * 0.28 : 0;
       jelly.sprite.material.opacity = 0.05 + contraction * 0.18;
       const farScale = THREE.MathUtils.clamp(distToPlayer / 120, 1, 2.1);
       jelly.sprite.scale.setScalar(jelly.size * 3 * farScale);
@@ -1318,8 +1571,10 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
       }
 
       jelly.group.rotation.y += dt * (0.04 + propulsion * 0.03);
-      jelly.group.rotation.x = Math.sin(t * 0.25 + jelly.rollPhase + jelly.velocityX * 0.6) * 0.07;
-      jelly.group.rotation.z = Math.cos(t * 0.22 + jelly.rollPhase + jelly.velocityZ * 0.6) * 0.06;
+      jelly.group.rotation.x =
+        Math.sin(t * 0.25 + jelly.rollPhase + jelly.velocityX * 0.6) * 0.07;
+      jelly.group.rotation.z =
+        Math.cos(t * 0.22 + jelly.rollPhase + jelly.velocityZ * 0.6) * 0.06;
 
       if (jelly.tiers.near.interior) {
         jelly.tiers.near.interior.manubrium.scale.y = 1 + contraction * 0.2;
@@ -1333,7 +1588,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`
         jelly.group.position.set(
           playerPos.x + (Math.random() - 0.5) * 240,
           playerPos.y + (Math.random() - 0.5) * 60 - 14,
-          playerPos.z + (Math.random() - 0.5) * 240
+          playerPos.z + (Math.random() - 0.5) * 240,
         );
         jelly.velocityX = 0;
         jelly.velocityY = 0;


### PR DESCRIPTION
## Problem

Jellyfish first spawn takes ~68ms, exceeding the 50ms `HEAVY_SPAWN_WARN_MS` budget and triggering a `[CreatureManager] Slow spawn` console warning. The bottleneck is synchronous creation of all 6 jellies × 3 LOD tiers in the constructor — each tier builds multiple TubeGeometry/CatmullRomCurve3 instances for oral arms, frills, tentacles, interior detail, etc.

## Solution

Stagger jellyfish creation across frames:

- Introduce `SYNC_JELLY_LIMIT = 2` — only build 2 jellies synchronously in the constructor (~23ms, well under the 50ms budget)
- Pre-compute spawn positions and colors for all requested jellies at construction time so deferred ones land in the same spatial cluster
- Defer remaining jellies to a `_pendingJellies` queue, draining 1 per `update()` frame
- This spreads the ~11ms-per-jelly cost across subsequent frames instead of blocking the spawn frame

## Results

- Constructor cost: ~68ms → ~23ms (2 of 6 built synchronously)
- Remaining 4 jellies appear over the next 4 frames (~11ms each, within normal frame budget)
- All features preserved: 6 jellies, 3 LOD tiers each, full shader/appendage animation, nematocyst systems, bell interior detail

Fixes #173