### PR TITLE
feat: add OutputPass for correct color-space output

### DIFF
--- a/src/shaders/UnderwaterEffect.js
+++ b/src/shaders/UnderwaterEffect.js
@@ -3,6 +3,7 @@ import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { qualityManager } from '../QualityManager.js';
 
 function deepFreeze(obj) {
@@ -364,6 +365,10 @@ export class UnderwaterEffect {
       this.tuning.bloom.radius * 2.4
     );
     this.composer.addPass(this.underwaterPass);
+
+    // OutputPass for correct sRGB conversion and tone mapping
+    this._outputPass = new OutputPass();
+    this.composer.addPass(this._outputPass);
 
     // UnrealBloomPass for ultra tier
     this._bloomPass = null;


### PR DESCRIPTION
Add `OutputPass` as the final pass in the `EffectComposer` chain in `UnderwaterEffect.js`.\n\nThree.js requires `OutputPass` at the end of the post-processing pipeline for proper sRGB conversion and tone mapping. Without it, the renderer's `ACESFilmicToneMapping` and `SRGBColorSpace` settings are not applied to the final composited output.\n\n### Changes\n- Import `OutputPass` from `three/addons/postprocessing/OutputPass.js`\n- Append `new OutputPass()` after the underwater `ShaderPass` and before bloom setup, ensuring it remains the last pass in the chain regardless of whether `UnrealBloomPass` is active (bloom is inserted before the underwater pass, so OutputPass stays last)\n\n### Chain order\n1. `RenderPass` — renders the scene\n2. `UnrealBloomPass` (optional, ultra tier only) — inserted before underwater pass\n3. `ShaderPass` (UnderwaterShader) — extinction, scatter, vignette, grading, bloom\n4. `OutputPass` — sRGB conversion and tone mapping ✅\n\nFixes #186