### PR TITLE
refactor: centralize depth-zone lighting policy with encounter modifier pattern

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -11,6 +11,7 @@ import { PreloadCoordinator } from "./PreloadCoordinator.js";
 import { AbyssEncounter } from "./encounters/AbyssEncounter.js";
 import { qualityManager } from "./QualityManager.js";
 import { PhysicsWorld } from "./physics/PhysicsWorld.js";
+import { LightingPolicy } from "./lighting/LightingPolicy.js";
 
 export class Game {
   constructor() {
@@ -87,19 +88,7 @@ export class Game {
       this.underwaterEffect.applySoftwareRendererPolicy();
     }
 
-    this.renderTuning = {
-      // Depth thresholds sourced from UnderwaterEffect to keep both in sync.
-      depthThresholds: this.underwaterEffect.tuning.depthThresholds,
-      exposure: {
-        surface: 0.76,
-        mid: 0.68,
-        deep: 0.6,
-        abyss: 0.56,
-        flashlightBoost: 0.16,
-        easing: 0.08,
-      },
-    };
-    this._targetExposure = this.renderer.toneMappingExposure;
+    this.lightingPolicy = new LightingPolicy();
     this._pointLightBudget = {
       shallowMax: qSettings.maxPointLights,
       deepMax: Math.max(3, Math.round(qSettings.maxPointLights * 0.6)),
@@ -185,8 +174,10 @@ export class Game {
       flora: this.flora,
       creatures: this.creatures,
       prepareDepthState: (depth) => {
-        this._updateEnvironmentForDepth(depth);
-        this._updateRenderPipelineForDepth(depth);
+        this.lightingPolicy.update(
+          depth, false, this._fog, this.ocean.ambientLight,
+          this.scene.background, this.renderer, this.underwaterEffect,
+        );
       },
     });
     this.preload.startMenuIdleWarmup();
@@ -353,7 +344,7 @@ export class Game {
 
     this.preload.cancel("restart");
     this.hud.resetRuntimeState();
-    this.abyssEncounter.reset(this.scene);
+    this.abyssEncounter.reset(this.scene, this.lightingPolicy);
     this.gameOver = false;
     this.flashlightOn = false;
     this.maxDepth = 0;
@@ -380,10 +371,10 @@ export class Game {
     this._descentLastCreatureCount = 0;
     this._descentLastTeaseTime = 0;
     this.descentOverlay.classList.remove("visible", "fade-out");
-    this._updateEnvironmentForDepth(0);
-    this._targetExposure = this.renderTuning.exposure.surface;
-    this.renderer.toneMappingExposure = this._targetExposure;
-    this.underwaterEffect.applyDepthScaleCap(0);
+    this.lightingPolicy.update(
+      0, false, this._fog, this.ocean.ambientLight,
+      this.scene.background, this.renderer, this.underwaterEffect,
+    );
     if (this.autoplay) {
       this._autoplayState = this._createAutoplayState();
       this.startAutoplay();
@@ -931,18 +922,25 @@ export class Game {
       this.hud.updateDiagnostics(this._getDiagnosticsSnapshot());
       this.hud.updateBackgroundLoading(this.preload.isDescentAssistActive());
 
-      // Update underwater fog based on depth, then let encounter override if active
-      this._updateEnvironmentForDepth(depth);
-      this._updateRenderPipelineForDepth(depth);
+      // Evaluate depth-zone base, let encounter set modifiers, then apply
+      this.lightingPolicy.evaluateBase(depth, this.flashlightOn);
       this.abyssEncounter.update(
         dt,
         depth,
         this.player,
         this.scene,
-        this._fog,
-        this.ocean.ambientLight,
+        this.lightingPolicy,
         this.hud,
         this.audio,
+      );
+      this.lightingPolicy.applyToScene(
+        depth,
+        this.flashlightOn,
+        this._fog,
+        this.ocean.ambientLight,
+        this.scene.background,
+        this.renderer,
+        this.underwaterEffect,
       );
 
       this.audio.update(dt, {
@@ -971,12 +969,6 @@ export class Game {
   }
 
   _initEnvironmentColors() {
-    // Pre-allocate reusable Color objects to avoid per-frame GC pressure
-    this._fogColor = new THREE.Color();
-    this._envColorA = new THREE.Color();
-    this._envColorB = new THREE.Color();
-    this._envColorC = new THREE.Color();
-    this._envColorD = new THREE.Color();
     this._fog = new THREE.Fog(0x006994, 5, 300);
     this.scene.fog = this._fog;
 
@@ -1067,99 +1059,6 @@ export class Game {
       graphics: this.graphicsDiagnostics,
       postProcess: this.underwaterEffect.getDiagnostics(),
     };
-  }
-
-  _updateEnvironmentForDepth(depth) {
-    // Overlapping depth bands for smoother transitions without hard visual steps.
-    const twilight = THREE.MathUtils.smoothstep(depth, 35, 210);
-    const darkZone = THREE.MathUtils.smoothstep(depth, 170, 520);
-    const abyss = THREE.MathUtils.smoothstep(depth, 430, 900);
-
-    this._envColorA.set(0x004b70); // surface teal-blue
-    this._envColorB.set(0x001b2b); // twilight blue-black
-    this._envColorC.set(0x02060d); // dark zone indigo-black
-    this._envColorD.set(0x010408); // near-black abyss with faint blue for silhouettes
-
-    this._fogColor.copy(this._envColorA);
-    this._fogColor.lerp(this._envColorB, twilight);
-    this._fogColor.lerp(this._envColorC, darkZone);
-    this._fogColor.lerp(this._envColorD, abyss);
-
-    const nearTwilight = THREE.MathUtils.lerp(5.0, 2.0, twilight);
-    const nearDark = THREE.MathUtils.lerp(nearTwilight, 0.7, darkZone);
-    let fogNear = THREE.MathUtils.lerp(nearDark, 0.3, abyss);
-
-    const farTwilight = THREE.MathUtils.lerp(220, 110, twilight);
-    const farDark = THREE.MathUtils.lerp(farTwilight, 58, darkZone);
-    let fogFar = THREE.MathUtils.lerp(farDark, 50, abyss);
-
-    const ambientTwilight = THREE.MathUtils.lerp(0.24, 0.12, twilight);
-    const ambientDark = THREE.MathUtils.lerp(ambientTwilight, 0.06, darkZone);
-    const ambientIntensity = THREE.MathUtils.lerp(ambientDark, 0.05, abyss);
-
-    // When flashlight is on, push fog back so the beam can illuminate the scene.
-    // The push is proportional to depth — stronger at deeper zones where fog is thickest.
-    if (this.flashlightOn) {
-      const pushStrength = THREE.MathUtils.smoothstep(depth, 100, 600);
-      fogNear += THREE.MathUtils.lerp(0.5, 3, pushStrength);
-      fogFar += THREE.MathUtils.lerp(8, 38, pushStrength);
-    }
-
-    this._fog.color.copy(this._fogColor);
-    this._fog.near = fogNear;
-    this._fog.far = fogFar;
-    this.scene.background.copy(this._fogColor);
-    this.ocean.ambientLight.intensity = ambientIntensity;
-  }
-
-  _updateRenderPipelineForDepth(depth) {
-    const thresholds = this.renderTuning.depthThresholds;
-    const exposure = this.renderTuning.exposure;
-
-    const midBlend = THREE.MathUtils.smoothstep(
-      depth,
-      thresholds.mid,
-      thresholds.deep,
-    );
-    const deepBlend = THREE.MathUtils.smoothstep(
-      depth,
-      thresholds.deep,
-      thresholds.abyss,
-    );
-
-    let target = THREE.MathUtils.lerp(exposure.surface, exposure.mid, midBlend);
-    target = THREE.MathUtils.lerp(target, exposure.deep, deepBlend);
-
-    const abyssBlend = THREE.MathUtils.smoothstep(
-      depth,
-      thresholds.abyss,
-      thresholds.abyss + 280,
-    );
-    target = THREE.MathUtils.lerp(target, exposure.abyss, abyssBlend);
-
-    if (this.flashlightOn) {
-      // Compensate a bit more at depth so flashlight readability remains consistent
-      // while fog attenuation and ambient falloff become stronger.
-      const flashlightComp = THREE.MathUtils.lerp(
-        exposure.flashlightBoost,
-        exposure.flashlightBoost * 1.3,
-        THREE.MathUtils.smoothstep(
-          depth,
-          thresholds.mid,
-          thresholds.abyss + 180,
-        ),
-      );
-      target += flashlightComp;
-    }
-
-    this._targetExposure = THREE.MathUtils.clamp(target, 0.5, 0.9);
-    this.renderer.toneMappingExposure = THREE.MathUtils.lerp(
-      this.renderer.toneMappingExposure,
-      this._targetExposure,
-      exposure.easing,
-    );
-    // Item 2: cap composer scale by depth band (deep zones tolerate cheaper FX).
-    this.underwaterEffect.applyDepthScaleCap(depth);
   }
 
   _createAutoplayState() {

--- a/src/encounters/AbyssEncounter.js
+++ b/src/encounters/AbyssEncounter.js
@@ -20,6 +20,9 @@ const RETREAT_DURATION = 6.0;
 /**
  * Scripted cinematic encounter: a colossal abyss entity drifts past the tiny sub.
  * Triggers once per session when the player reaches ~650m depth.
+ *
+ * Instead of directly mutating fog/ambient, the encounter submits a named
+ * modifier to the LightingPolicy which blends it on top of the depth-zone base.
  */
 export class AbyssEncounter {
   constructor() {
@@ -29,20 +32,17 @@ export class AbyssEncounter {
     this.entity = null;
     this.entityLights = [];
 
-    // Saved environment values to restore after encounter
+    // Saved base-profile values captured at trigger time
     this._savedFogNear = 0;
     this._savedFogFar = 0;
-    this._savedFogColor = new THREE.Color();
     this._savedAmbientIntensity = 0;
 
-    // Per-frame environment values (written by _updateEnvironmentForDepth before our update)
-    this._envFogNear = 0;
-    this._envFogFar = 0;
-    this._envAmbient = 0;
-
-    // Encounter fog targets
+    // Encounter fog targets (tightest point)
     this._closedFogNear = 1;
     this._closedFogFar = 60;
+
+    // Reusable modifier object submitted to LightingPolicy
+    this._modifier = { fogNear: 0, fogFar: 0, ambientIntensity: 0, weight: 0 };
 
     // Entity animation state
     this._entityStartPos = new THREE.Vector3();
@@ -50,54 +50,44 @@ export class AbyssEncounter {
     this._entityDriftDir = new THREE.Vector3();
   }
 
-  reset(scene) {
+  reset(scene, lightingPolicy) {
     this._despawnEntity(scene);
+    if (lightingPolicy) lightingPolicy.removeModifier('abyss_encounter');
     this.state = State.IDLE;
     this.stateTime = 0;
     this.completed = false;
     this._savedFogNear = 0;
     this._savedFogFar = 0;
-    this._savedFogColor.set(0x000000);
     this._savedAmbientIntensity = 0;
-    this._envFogNear = 0;
-    this._envFogFar = 0;
-    this._envAmbient = 0;
+    this._modifier.weight = 0;
     this._entityStartPos.set(0, 0, 0);
     this._entityEndPos.set(0, 0, 0);
     this._entityDriftDir.set(0, 0, 0);
   }
 
-  update(delta, depth, player, scene, fog, ambientLight, hud, audio) {
+  update(delta, depth, player, scene, lightingPolicy, hud, audio) {
     if (this.completed) return;
 
     this.stateTime += delta;
 
-    // Capture the environment's intended values each frame (set before us by _updateEnvironmentForDepth)
-    // These serve as restoration targets during RETREAT
-    if (this.state !== State.IDLE) {
-      this._envFogNear = fog.near;
-      this._envFogFar = fog.far;
-      this._envAmbient = ambientLight.intensity;
-    }
-
     switch (this.state) {
       case State.IDLE:
-        this._updateIdle(depth, player, scene, fog, ambientLight, hud);
+        this._updateIdle(depth, player, scene, lightingPolicy, hud);
         break;
       case State.TRIGGERED:
-        this._updateTriggered(delta, scene, fog, ambientLight, hud, audio);
+        this._updateTriggered(delta, scene, lightingPolicy, hud, audio);
         break;
       case State.FOG_CLOSING:
-        this._updateFogClosing(delta, fog, ambientLight, hud, audio);
+        this._updateFogClosing(delta, lightingPolicy, hud, audio);
         break;
       case State.REVEAL:
-        this._updateReveal(delta, fog, ambientLight);
+        this._updateReveal(delta, lightingPolicy);
         break;
       case State.DRIFT:
-        this._updateDrift(delta, fog, ambientLight, audio);
+        this._updateDrift(delta, lightingPolicy, audio);
         break;
       case State.RETREAT:
-        this._updateRetreat(delta, scene, fog, ambientLight);
+        this._updateRetreat(delta, scene, lightingPolicy);
         break;
     }
 
@@ -109,21 +99,21 @@ export class AbyssEncounter {
 
   // --- State handlers ---
 
-  _updateIdle(depth, player, scene, fog, ambientLight, hud) {
+  _updateIdle(depth, player, scene, lightingPolicy, hud) {
     if (depth >= TRIGGER_DEPTH) {
       this._transition(State.TRIGGERED);
-      // Save current environment state
-      this._savedFogNear = fog.near;
-      this._savedFogFar = fog.far;
-      this._savedFogColor.copy(fog.color);
-      this._savedAmbientIntensity = ambientLight.intensity;
+      // Capture base profile at trigger time
+      const base = lightingPolicy.getBaseProfile();
+      this._savedFogNear = base.fogNear;
+      this._savedFogFar = base.fogFar;
+      this._savedAmbientIntensity = base.ambient;
 
       // Spawn entity ahead and below the player
       this._spawnEntity(scene, player);
     }
   }
 
-  _updateTriggered(delta, scene, fog, ambientLight, hud, audio) {
+  _updateTriggered(delta, scene, lightingPolicy, hud, audio) {
     // Immediate transition to fog closing — brief pause for dramatic effect
     if (this.stateTime > 0.5) {
       hud._showWarning('MASSIVE ENTITY DETECTED', 4000);
@@ -132,16 +122,16 @@ export class AbyssEncounter {
     }
   }
 
-  _updateFogClosing(delta, fog, ambientLight, hud, audio) {
+  _updateFogClosing(delta, lightingPolicy, hud, audio) {
     const t = Math.min(this.stateTime / FOG_CLOSE_DURATION, 1);
     const ease = t * t; // ease-in
 
     // Tighten fog dramatically
-    fog.near = THREE.MathUtils.lerp(this._savedFogNear, this._closedFogNear, ease);
-    fog.far = THREE.MathUtils.lerp(this._savedFogFar, this._closedFogFar, ease);
-
-    // Reduce ambient light to near-zero
-    ambientLight.intensity = THREE.MathUtils.lerp(this._savedAmbientIntensity, 0.001, ease);
+    this._modifier.fogNear = THREE.MathUtils.lerp(this._savedFogNear, this._closedFogNear, ease);
+    this._modifier.fogFar = THREE.MathUtils.lerp(this._savedFogFar, this._closedFogFar, ease);
+    this._modifier.ambientIntensity = THREE.MathUtils.lerp(this._savedAmbientIntensity, 0.001, ease);
+    this._modifier.weight = 1;
+    lightingPolicy.setModifier('abyss_encounter', this._modifier);
 
     if (t >= 1) {
       audio?.playEncounterReveal();
@@ -149,26 +139,26 @@ export class AbyssEncounter {
     }
   }
 
-  _updateReveal(delta, fog, ambientLight) {
+  _updateReveal(delta, lightingPolicy) {
     const t = Math.min(this.stateTime / REVEAL_DURATION, 1);
     const ease = t * t * (3 - 2 * t); // smoothstep
 
     // Gradually widen fog to reveal the entity's scale
-    fog.near = THREE.MathUtils.lerp(this._closedFogNear, this._savedFogNear * 0.5, ease);
-    fog.far = THREE.MathUtils.lerp(this._closedFogFar, this._savedFogFar * 0.8, ease);
+    this._modifier.fogNear = THREE.MathUtils.lerp(this._closedFogNear, this._savedFogNear * 0.5, ease);
+    this._modifier.fogFar = THREE.MathUtils.lerp(this._closedFogFar, this._savedFogFar * 0.8, ease);
+    this._modifier.ambientIntensity = THREE.MathUtils.lerp(0.001, 0.008, ease);
+    this._modifier.weight = 1;
+    lightingPolicy.setModifier('abyss_encounter', this._modifier);
 
     // Pulse bioluminescence on the entity
     this._pulseBioluminescence(t);
-
-    // Slightly raise ambient so silhouette is visible
-    ambientLight.intensity = THREE.MathUtils.lerp(0.001, 0.008, ease);
 
     if (t >= 1) {
       this._transition(State.DRIFT);
     }
   }
 
-  _updateDrift(delta, fog, ambientLight, audio) {
+  _updateDrift(delta, lightingPolicy, audio) {
     const t = Math.min(this.stateTime / DRIFT_DURATION, 1);
     const ease = t * t * (3 - 2 * t);
 
@@ -176,11 +166,11 @@ export class AbyssEncounter {
     this.entity.position.lerpVectors(this._entityStartPos, this._entityEndPos, ease);
 
     // Slowly widen fog further during drift
-    fog.near = THREE.MathUtils.lerp(this._savedFogNear * 0.5, this._savedFogNear * 0.7, ease);
-    fog.far = THREE.MathUtils.lerp(this._savedFogFar * 0.8, this._savedFogFar * 0.9, ease);
-
-    // Gradually restore ambient
-    ambientLight.intensity = THREE.MathUtils.lerp(0.008, this._savedAmbientIntensity * 0.5, ease);
+    this._modifier.fogNear = THREE.MathUtils.lerp(this._savedFogNear * 0.5, this._savedFogNear * 0.7, ease);
+    this._modifier.fogFar = THREE.MathUtils.lerp(this._savedFogFar * 0.8, this._savedFogFar * 0.9, ease);
+    this._modifier.ambientIntensity = THREE.MathUtils.lerp(0.008, this._savedAmbientIntensity * 0.5, ease);
+    this._modifier.weight = 1;
+    lightingPolicy.setModifier('abyss_encounter', this._modifier);
 
     // Keep pulsing bioluminescence
     this._pulseBioluminescence(0.5 + t * 0.5);
@@ -191,7 +181,7 @@ export class AbyssEncounter {
     }
   }
 
-  _updateRetreat(delta, scene, fog, ambientLight) {
+  _updateRetreat(delta, scene, lightingPolicy) {
     const t = Math.min(this.stateTime / RETREAT_DURATION, 1);
     const ease = t * t * (3 - 2 * t);
 
@@ -213,15 +203,19 @@ export class AbyssEncounter {
       light.intensity = light.userData.baseIntensity * (1 - ease);
     }
 
-    // Restore environment toward current depth-appropriate values
-    fog.near = THREE.MathUtils.lerp(this._savedFogNear * 0.7, this._envFogNear, ease);
-    fog.far = THREE.MathUtils.lerp(this._savedFogFar * 0.9, this._envFogFar, ease);
-    ambientLight.intensity = THREE.MathUtils.lerp(
-      this._savedAmbientIntensity * 0.5, this._envAmbient, ease
+    // Blend modifier back toward current depth-zone base values
+    const base = lightingPolicy.getBaseProfile();
+    this._modifier.fogNear = THREE.MathUtils.lerp(this._savedFogNear * 0.7, base.fogNear, ease);
+    this._modifier.fogFar = THREE.MathUtils.lerp(this._savedFogFar * 0.9, base.fogFar, ease);
+    this._modifier.ambientIntensity = THREE.MathUtils.lerp(
+      this._savedAmbientIntensity * 0.5, base.ambient, ease
     );
+    this._modifier.weight = 1;
+    lightingPolicy.setModifier('abyss_encounter', this._modifier);
 
     if (t >= 1) {
-      // Clean up entity from scene
+      // Clean up
+      lightingPolicy.removeModifier('abyss_encounter');
       this._despawnEntity(scene);
       this.state = State.COMPLETE;
       this.completed = true;

--- a/src/lighting/LightingPolicy.js
+++ b/src/lighting/LightingPolicy.js
@@ -1,0 +1,250 @@
+import * as THREE from 'three';
+
+/**
+ * Authoritative depth-zone thresholds shared by the lighting policy and
+ * underwater post-FX pipeline. Editing these values is the single tuning
+ * surface for depth-zone boundaries.
+ */
+export const DEPTH_THRESHOLDS = Object.freeze({
+  mid: 130,
+  deep: 340,
+  abyss: 720,
+});
+
+/**
+ * Centralized depth-zone lighting profiles.
+ * Single source of truth for fog, ambient, and exposure parameters.
+ * Depth-zone tuning (#184, #185) can be done by editing this data.
+ */
+export const DEPTH_ZONE_PROFILES = Object.freeze({
+  fog: Object.freeze({
+    colors: Object.freeze({
+      surface: 0x004b70,
+      twilight: 0x001b2b,
+      darkZone: 0x02060d,
+      abyss: 0x010408,
+    }),
+    bands: Object.freeze({
+      twilight: Object.freeze({ start: 35, end: 210 }),
+      darkZone: Object.freeze({ start: 170, end: 520 }),
+      abyss: Object.freeze({ start: 430, end: 900 }),
+    }),
+    near: Object.freeze({ surface: 5.0, twilight: 2.0, darkZone: 0.7, abyss: 0.3 }),
+    far: Object.freeze({ surface: 220, twilight: 110, darkZone: 58, abyss: 50 }),
+  }),
+  ambient: Object.freeze({
+    surface: 0.24,
+    twilight: 0.12,
+    darkZone: 0.06,
+    abyss: 0.05,
+  }),
+  exposure: Object.freeze({
+    surface: 0.76,
+    mid: 0.68,
+    deep: 0.6,
+    abyss: 0.56,
+    flashlightBoost: 0.16,
+    easing: 0.08,
+  }),
+  flashlightFogPush: Object.freeze({
+    depthRange: Object.freeze({ start: 100, end: 600 }),
+    nearAdd: Object.freeze({ min: 0.5, max: 3 }),
+    farAdd: Object.freeze({ min: 8, max: 38 }),
+  }),
+});
+
+/**
+ * Centralized lighting-policy engine.
+ *
+ * Evaluates depth-zone profiles, applies encounter/effect modifiers, and
+ * writes fog, ambient, background, and exposure to scene state in a single
+ * per-frame update call.
+ *
+ * Encounters contribute named modifiers instead of directly mutating scene
+ * state. The policy blends active modifiers on top of the base profile.
+ */
+export class LightingPolicy {
+  constructor() {
+    this.profiles = DEPTH_ZONE_PROFILES;
+    this.depthThresholds = DEPTH_THRESHOLDS;
+
+    this._modifiers = new Map();
+
+    // Pre-allocated color temporaries (zero per-frame GC pressure)
+    this._fogColor = new THREE.Color();
+    this._colorA = new THREE.Color();
+    this._colorB = new THREE.Color();
+    this._colorC = new THREE.Color();
+    this._colorD = new THREE.Color();
+
+    // Base profile results (before modifiers)
+    this._baseFogNear = 5;
+    this._baseFogFar = 300;
+    this._baseAmbient = 0.24;
+
+    // Exposure state
+    this._targetExposure = DEPTH_ZONE_PROFILES.exposure.surface;
+  }
+
+  /**
+   * Register or update a named modifier overlay.
+   *
+   * Modifiers blend on top of the base depth-zone profile each frame.
+   * @param {string} id
+   * @param {{ fogNear?: number, fogFar?: number, ambientIntensity?: number, weight: number }} modifier
+   */
+  setModifier(id, modifier) {
+    this._modifiers.set(id, modifier);
+  }
+
+  removeModifier(id) {
+    this._modifiers.delete(id);
+  }
+
+  /**
+   * Current base profile values for the most recently evaluated depth.
+   * Useful for encounters blending back toward the base.
+   */
+  getBaseProfile() {
+    return {
+      fogNear: this._baseFogNear,
+      fogFar: this._baseFogFar,
+      ambient: this._baseAmbient,
+    };
+  }
+
+  get targetExposure() {
+    return this._targetExposure;
+  }
+
+  /**
+   * Single per-frame update (convenience wrapper).
+   * Use when no encounter/modifier needs to read the base between evaluation
+   * and application (e.g. during preload warm-up).
+   */
+  update(depth, flashlightOn, fog, ambientLight, sceneBackground, renderer, underwaterEffect) {
+    this.evaluateBase(depth, flashlightOn);
+    this.applyToScene(depth, flashlightOn, fog, ambientLight, sceneBackground, renderer, underwaterEffect);
+  }
+
+  /**
+   * Phase 1: evaluate the depth-zone base profile for the current depth.
+   * After this call, getBaseProfile() returns values for this frame.
+   * Call this before encounter updates so they can read the base.
+   */
+  evaluateBase(depth, flashlightOn) {
+    this._evaluateBaseProfile(depth, flashlightOn);
+  }
+
+  /**
+   * Phase 2: blend modifiers onto the base and write fog, ambient,
+   * background, exposure, and depth-scale cap to the scene.
+   */
+  applyToScene(depth, flashlightOn, fog, ambientLight, sceneBackground, renderer, underwaterEffect) {
+
+    // 2. Start with base values
+    let fogNear = this._baseFogNear;
+    let fogFar = this._baseFogFar;
+    let ambient = this._baseAmbient;
+
+    // 3. Apply active modifiers (blended by weight)
+    for (const mod of this._modifiers.values()) {
+      const w = THREE.MathUtils.clamp(mod.weight ?? 0, 0, 1);
+      if (w === 0) continue;
+      if (mod.fogNear !== undefined) fogNear = THREE.MathUtils.lerp(fogNear, mod.fogNear, w);
+      if (mod.fogFar !== undefined) fogFar = THREE.MathUtils.lerp(fogFar, mod.fogFar, w);
+      if (mod.ambientIntensity !== undefined) ambient = THREE.MathUtils.lerp(ambient, mod.ambientIntensity, w);
+    }
+
+    // 4. Write to scene state
+    fog.color.copy(this._fogColor);
+    fog.near = fogNear;
+    fog.far = fogFar;
+    sceneBackground.copy(this._fogColor);
+    ambientLight.intensity = ambient;
+
+    // 5. Update exposure
+    this._updateExposure(depth, flashlightOn, renderer);
+
+    // 6. Depth-band scale cap for underwater post-FX
+    underwaterEffect.applyDepthScaleCap(depth);
+  }
+
+  // -- internal -----------------------------------------------------------
+
+  _evaluateBaseProfile(depth, flashlightOn) {
+    const p = this.profiles;
+    const bands = p.fog.bands;
+
+    const twilight = THREE.MathUtils.smoothstep(depth, bands.twilight.start, bands.twilight.end);
+    const darkZone = THREE.MathUtils.smoothstep(depth, bands.darkZone.start, bands.darkZone.end);
+    const abyss = THREE.MathUtils.smoothstep(depth, bands.abyss.start, bands.abyss.end);
+
+    // Fog color
+    this._colorA.set(p.fog.colors.surface);
+    this._colorB.set(p.fog.colors.twilight);
+    this._colorC.set(p.fog.colors.darkZone);
+    this._colorD.set(p.fog.colors.abyss);
+
+    this._fogColor.copy(this._colorA);
+    this._fogColor.lerp(this._colorB, twilight);
+    this._fogColor.lerp(this._colorC, darkZone);
+    this._fogColor.lerp(this._colorD, abyss);
+
+    // Fog near / far
+    const nearTwilight = THREE.MathUtils.lerp(p.fog.near.surface, p.fog.near.twilight, twilight);
+    const nearDark = THREE.MathUtils.lerp(nearTwilight, p.fog.near.darkZone, darkZone);
+    let fogNear = THREE.MathUtils.lerp(nearDark, p.fog.near.abyss, abyss);
+
+    const farTwilight = THREE.MathUtils.lerp(p.fog.far.surface, p.fog.far.twilight, twilight);
+    const farDark = THREE.MathUtils.lerp(farTwilight, p.fog.far.darkZone, darkZone);
+    let fogFar = THREE.MathUtils.lerp(farDark, p.fog.far.abyss, abyss);
+
+    // Ambient
+    const ambientTwilight = THREE.MathUtils.lerp(p.ambient.surface, p.ambient.twilight, twilight);
+    const ambientDark = THREE.MathUtils.lerp(ambientTwilight, p.ambient.darkZone, darkZone);
+    const ambientIntensity = THREE.MathUtils.lerp(ambientDark, p.ambient.abyss, abyss);
+
+    // Flashlight fog push
+    if (flashlightOn) {
+      const push = p.flashlightFogPush;
+      const pushStrength = THREE.MathUtils.smoothstep(depth, push.depthRange.start, push.depthRange.end);
+      fogNear += THREE.MathUtils.lerp(push.nearAdd.min, push.nearAdd.max, pushStrength);
+      fogFar += THREE.MathUtils.lerp(push.farAdd.min, push.farAdd.max, pushStrength);
+    }
+
+    this._baseFogNear = fogNear;
+    this._baseFogFar = fogFar;
+    this._baseAmbient = ambientIntensity;
+  }
+
+  _updateExposure(depth, flashlightOn, renderer) {
+    const exp = this.profiles.exposure;
+    const t = this.depthThresholds;
+
+    const midBlend = THREE.MathUtils.smoothstep(depth, t.mid, t.deep);
+    const deepBlend = THREE.MathUtils.smoothstep(depth, t.deep, t.abyss);
+
+    let target = THREE.MathUtils.lerp(exp.surface, exp.mid, midBlend);
+    target = THREE.MathUtils.lerp(target, exp.deep, deepBlend);
+
+    const abyssBlend = THREE.MathUtils.smoothstep(depth, t.abyss, t.abyss + 280);
+    target = THREE.MathUtils.lerp(target, exp.abyss, abyssBlend);
+
+    if (flashlightOn) {
+      const flashlightComp = THREE.MathUtils.lerp(
+        exp.flashlightBoost,
+        exp.flashlightBoost * 1.3,
+        THREE.MathUtils.smoothstep(depth, t.mid, t.abyss + 180),
+      );
+      target += flashlightComp;
+    }
+
+    this._targetExposure = THREE.MathUtils.clamp(target, 0.5, 0.9);
+    renderer.toneMappingExposure = THREE.MathUtils.lerp(
+      renderer.toneMappingExposure,
+      this._targetExposure,
+      exp.easing,
+    );
+  }
+}

--- a/src/shaders/UnderwaterEffect.js
+++ b/src/shaders/UnderwaterEffect.js
@@ -5,6 +5,7 @@ import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { qualityManager } from '../QualityManager.js';
+import { DEPTH_THRESHOLDS } from '../lighting/LightingPolicy.js';
 
 function deepFreeze(obj) {
   Object.freeze(obj);
@@ -15,11 +16,7 @@ function deepFreeze(obj) {
 }
 
 const RENDER_PIPELINE_TUNING = deepFreeze({
-  depthThresholds: {
-    mid: 130,
-    deep: 340,
-    abyss: 720,
-  },
+  depthThresholds: DEPTH_THRESHOLDS,
   extinction: {
     r: 0.38,
     g: 0.065,
@@ -850,7 +847,7 @@ export class UnderwaterEffect {
 
   /**
    * Item 2: Cap the maximum composer scale for the current depth band.
-   * Called each frame from Game._updateRenderPipelineForDepth.
+   * Called each frame from LightingPolicy.applyToScene.
    * Deep/abyss zones tolerate cheaper post-FX — visual sensitivity is lower.
    */
   applyDepthScaleCap(depth) {


### PR DESCRIPTION
## Summary

Consolidates the scattered depth-zone lighting logic into a single policy surface (`src/lighting/LightingPolicy.js`) so fog, ambient, exposure, and depth thresholds are defined in one place. Encounters contribute named modifiers instead of directly mutating scene state.

## Changes

### New: `src/lighting/LightingPolicy.js`
- **`DEPTH_THRESHOLDS`** — single source of truth for mid/deep/abyss boundaries (imported by UnderwaterEffect)
- **`DEPTH_ZONE_PROFILES`** — frozen profile data for fog colors, fog near/far, ambient intensity, exposure, and flashlight fog push
- **`LightingPolicy` class** — evaluates depth-zone base profiles, accepts named modifiers from encounters, and applies blended results to fog, ambient light, background, and exposure in a single call
- Two-phase API: `evaluateBase()` → encounters read base & set modifiers → `applyToScene()` (plus convenience `update()` for preload/restart)

### Modified: `src/Game.js`
- Replaced `_updateEnvironmentForDepth()` and `_updateRenderPipelineForDepth()` with `LightingPolicy` calls
- Removed duplicated depth-zone profile data and `renderTuning` property
- Animation loop uses two-phase flow: base evaluation → encounter modifier → scene application

### Modified: `src/encounters/AbyssEncounter.js`
- Replaced direct `fog.near = ...`, `fog.far = ...`, `ambientLight.intensity = ...` writes with `lightingPolicy.setModifier('abyss_encounter', ...)` 
- Reusable modifier object with weight-based blending; smooth blend-in during FOG_CLOSING and blend-out during RETREAT
- Uses `lightingPolicy.getBaseProfile()` during RETREAT to blend back toward current depth-appropriate values

### Modified: `src/shaders/UnderwaterEffect.js`
- Imports `DEPTH_THRESHOLDS` from `LightingPolicy` instead of defining its own copy

## Acceptance Criteria
- ✅ One lighting-policy surface owns depth-zone profiles for fog, ambient, exposure, and depth thresholds
- ✅ AbyssEncounter contributes a modifier instead of directly mutating fog/ambient
- ✅ Modifier blends in/out smoothly (same phase timing preserved)
- ✅ Depth-zone tuning for #184 and #185 can be done by editing `DEPTH_ZONE_PROFILES` in one location
- ✅ Existing visual behavior preserved (identical interpolation math and values)
- ✅ `npm run build` passes

Fixes #188