### PR TITLE
feat: refactor point-light budget with semantic categories and player-light protection

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -1524,6 +1524,8 @@ export class Game {
     this.scene.traverse((obj) => {
       if (!obj.isPointLight) return;
       if (obj === this.player.subLight) return;
+      const cat = obj.userData.duwCategory;
+      if (cat === 'player_practical' || cat === 'player_headlight') return;
 
       if (obj.userData.duwBaseIntensity === undefined) {
         obj.userData.duwBaseIntensity = obj.intensity;
@@ -1565,8 +1567,13 @@ export class Game {
       // Hysteresis: boost score for currently-active lights to prevent flip-flopping
       const isActive = (light.userData.duwTargetIntensity ?? 0) > 0.01;
       const hysteresis = isActive ? 1.2 : 1.0;
+      // Category priority tiebreaker: encounter_hero > creature_bio > flora_decor
+      const catPriority = light.userData.duwCategory === 'encounter_hero' ? 1.15
+        : light.userData.duwCategory === 'creature_bio' ? 1.10
+        : light.userData.duwCategory === 'flora_decor' ? 1.05
+        : 1.0;
       light.userData.duwScore =
-        ((baseIntensity + 0.001) / (distanceSq + 1)) * hysteresis;
+        ((baseIntensity + 0.001) / (distanceSq + 1)) * hysteresis * catPriority;
       light.userData.duwTargetIntensity = 0;
     }
 

--- a/src/creatures/AbyssWraith.js
+++ b/src/creatures/AbyssWraith.js
@@ -132,6 +132,7 @@ export class AbyssWraith {
     this.group.add(blade);
 
     this.eyeLight = new THREE.PointLight(0xff2200, 1.5, 12);
+    this.eyeLight.userData.duwCategory = 'creature_bio';
     this.eyeLight.position.set(0.8, 0.15, 0);
     this.group.add(this.eyeLight);
 

--- a/src/creatures/AbyssalMaw.js
+++ b/src/creatures/AbyssalMaw.js
@@ -260,6 +260,7 @@ export class AbyssalMaw {
 
     // PointLight only on near tier (budget single light for inner glow)
     this.innerLight = new THREE.PointLight(0xff0033, 2, 15);
+    this.innerLight.userData.duwCategory = 'creature_bio';
     this.innerLight.position.z = -2;
     this.tiers.near.group.add(this.innerLight);
 

--- a/src/creatures/Anglerfish.js
+++ b/src/creatures/Anglerfish.js
@@ -431,6 +431,7 @@ export class Anglerfish {
     let lureLight = null;
     if (isNear) {
       lureLight = new THREE.PointLight(0x46ffb0, 2.8, 24);
+      lureLight.userData.duwCategory = 'creature_bio';
       lureLight.position.copy(lureBulb.position);
       lurePivot.add(lureLight);
     }

--- a/src/creatures/BirthSac.js
+++ b/src/creatures/BirthSac.js
@@ -336,6 +336,7 @@ export class BirthSac {
     g.add(new THREE.Mesh(silGeo, silMat));
 
     const glow = new THREE.PointLight(0x660022, 0.6, 8);
+    glow.userData.duwCategory = 'creature_bio';
     g.add(glow);
 
     return { group: g, sacMat: silMat, sacs: [], glow, connTissues: [] };
@@ -490,6 +491,7 @@ export class BirthSac {
 
     // Single point light per tier — emissive glow (no per-sac lights)
     const glow = new THREE.PointLight(0x660022, 0.8, 8);
+    glow.userData.duwCategory = 'creature_bio';
     tierGroup.add(glow);
 
     return { group: tierGroup, core, sacMat, sacs, glow, connTissues, profile };

--- a/src/creatures/DeepOne.js
+++ b/src/creatures/DeepOne.js
@@ -231,6 +231,7 @@ export class DeepOne {
 
     // Single point light — near tier only; mid/far use emissive-only glow
     this._eyeLight = new THREE.PointLight(0x440000, 0.5, 4 * this.scale);
+    this._eyeLight.userData.duwCategory = 'creature_bio';
     this._eyeLight.position.set(0, 2.0, 0.8);
     nearTier.group.add(this._eyeLight);
 

--- a/src/creatures/FacelessOne.js
+++ b/src/creatures/FacelessOne.js
@@ -39,6 +39,7 @@ export class FacelessOne {
 
     // Light only on near tier
     this.glow = new THREE.PointLight(0x1a0a2e, 1.2, 18);
+    this.glow.userData.duwCategory = 'creature_bio';
     this.glow.position.set(0, 1.5, 0);
     this.tiers.near.group.add(this.glow);
 

--- a/src/creatures/GhostShark.js
+++ b/src/creatures/GhostShark.js
@@ -381,6 +381,7 @@ export class GhostShark {
 
     // ── Glow: dim fill light — emissive materials carry the primary glow ─
     const glow = new THREE.PointLight(0x66ffaa, isFar ? 0.08 : 0.12, 10);
+    glow.userData.duwCategory = 'creature_bio';
     group.add(glow);
 
     return {

--- a/src/creatures/Harvester.js
+++ b/src/creatures/Harvester.js
@@ -105,6 +105,7 @@ export class Harvester {
     this.group.add(eye);
 
     this.eyeLight = new THREE.PointLight(0xffaa00, 1, 12);
+    this.eyeLight.userData.duwCategory = 'creature_bio';
     this.eyeLight.position.copy(eye.position);
     this.group.add(this.eyeLight);
 

--- a/src/creatures/Husk.js
+++ b/src/creatures/Husk.js
@@ -88,6 +88,7 @@ export class Husk {
 
     // Residual energy leak from cracked shell
     this.glow = new THREE.PointLight(0x1a0828, 0.6, 10);
+    this.glow.userData.duwCategory = 'creature_bio';
     this.glow.position.set(0, 0, 0);
     this.group.add(this.glow);
 

--- a/src/creatures/IronWhale.js
+++ b/src/creatures/IronWhale.js
@@ -35,6 +35,7 @@ export class IronWhale {
 
     // Eye light on near tier only
     this.eyeLight = new THREE.PointLight(0x2244aa, 1.5, 25);
+    this.eyeLight.userData.duwCategory = 'creature_bio';
     this.eyeLight.position.set(5, 0.5, 0);
     lod.levels[0].object.add(this.eyeLight);
 

--- a/src/creatures/Jellyfish.js
+++ b/src/creatures/Jellyfish.js
@@ -1325,6 +1325,7 @@ totalEmissiveRadiance += diffuseColor.rgb * (vPulse - 0.76) * 0.42;`,
     group.add(sprite);
 
     const light = new THREE.PointLight(color, 0.42, 8);
+    light.userData.duwCategory = 'creature_bio';
     light.position.y = -0.1;
     group.add(light);
 

--- a/src/creatures/Leviathan.js
+++ b/src/creatures/Leviathan.js
@@ -39,6 +39,7 @@ export class Leviathan {
 
     // Eye light only on near tier
     this.eyeLight = new THREE.PointLight(0xff2200, 2, 30);
+    this.eyeLight.userData.duwCategory = 'creature_bio';
     this.eyeLight.position.set(3, 1.2, 0);
     this.tiers.near.group.add(this.eyeLight);
 

--- a/src/creatures/MechOctopus.js
+++ b/src/creatures/MechOctopus.js
@@ -115,6 +115,7 @@ export class MechOctopus {
 
     // Eye point-light lives on near tier only
     this.eyeLight = new THREE.PointLight(0xffaa00, 0.8, 10);
+    this.eyeLight.userData.duwCategory = 'creature_bio';
     this.eyeLight.position.set(0.5, 0, 0);
     this._tierGroups.near.add(this.eyeLight);
 

--- a/src/creatures/RibCage.js
+++ b/src/creatures/RibCage.js
@@ -100,6 +100,7 @@ export class RibCage {
 
     // Dim inner glow
     this.glow = new THREE.PointLight(0x440022, 1, 10);
+    this.glow.userData.duwCategory = 'creature_bio';
     this.group.add(this.glow);
 
     const s = 2.5 + Math.random() * 2;

--- a/src/creatures/Sentinel.js
+++ b/src/creatures/Sentinel.js
@@ -57,6 +57,7 @@ export class Sentinel {
     this.group.add(pupil);
 
     this.eyeLight = new THREE.PointLight(0xffcc00, 2, 20);
+    this.eyeLight.userData.duwCategory = 'creature_bio';
     this.eyeLight.position.set(0.3, 6, 0);
     this.group.add(this.eyeLight);
 

--- a/src/encounters/AbyssEncounter.js
+++ b/src/encounters/AbyssEncounter.js
@@ -355,6 +355,7 @@ export class AbyssEncounter {
           const eyeLight = new THREE.PointLight(0xff3300, 3, 40);
           eyeLight.position.copy(eye.position);
           eyeLight.userData.baseIntensity = 3;
+          eyeLight.userData.duwCategory = 'encounter_hero';
           this.entity.add(eyeLight);
           this.entityLights.push(eyeLight);
         }
@@ -371,6 +372,7 @@ export class AbyssEncounter {
         (Math.random() - 0.5) * 30
       );
       bioLight.userData.baseIntensity = 5;
+      bioLight.userData.duwCategory = 'encounter_hero';
       this.entity.add(bioLight);
       this.entityLights.push(bioLight);
     }

--- a/src/environment/Flora.js
+++ b/src/environment/Flora.js
@@ -141,6 +141,7 @@ export class Flora {
 
     for (const lightData of payload.orbLights) {
       const light = new THREE.PointLight(lightData.color, lightData.intensity, lightData.distance);
+      light.userData.duwCategory = 'flora_decor';
       light.position.set(lightData.x, lightData.y, lightData.z);
       group.add(light);
     }

--- a/src/environment/Ocean.js
+++ b/src/environment/Ocean.js
@@ -201,6 +201,7 @@ export class Ocean {
     this.causticLights = [];
     for (let i = 0; i < 10; i++) {
       const light = new THREE.PointLight(0x88ccff, 0.5, 70);
+      light.userData.duwCategory = 'flora_decor';
       light.position.set(
         (Math.random() - 0.5) * 50,
         -3 - Math.random() * 18,

--- a/src/player/ExternalLightingSystem.js
+++ b/src/player/ExternalLightingSystem.js
@@ -71,6 +71,7 @@ export class ExternalLightingSystem {
       spot.target.position.set(x, 0, -1);
       spot.userData.baseIntensity = cfg.headlightIntensity;
       spot.userData.baseRange = cfg.headlightRange;
+      spot.userData.duwCategory = 'player_headlight';
       this.group.add(spot);
       this.group.add(spot.target);
       this.headlights.push(spot);
@@ -105,6 +106,7 @@ export class ExternalLightingSystem {
       light.position.set(item.position[0], item.position[1], item.position[2]);
       light.userData.baseIntensity = intensity;
       light.userData.baseRange = cfg.hullRange;
+      light.userData.duwCategory = 'player_practical';
       this.group.add(light);
       this.hullLights.push(light);
     }


### PR DESCRIPTION
## Summary

Refactors the point-light budget system to use semantic categories (`light.userData.duwCategory`) and ensures player-owned lights are protected from budget suppression.

### Changes

**ExternalLightingSystem** — Tags hull lights as `player_practical` and headlights as `player_headlight` at construction time.

**Game.js `_refreshManagedPointLights()`** — Skips lights tagged `player_practical` or `player_headlight` from the managed pool (same pattern as `player.subLight` exclusion). Player hull/headlights are never budget-dimmed.

**Game.js `_retargetPointLights()`** — Adds category priority as a score multiplier tiebreaker:
- `encounter_hero` → 1.15×
- `creature_bio` → 1.10×
- `flora_decor` → 1.05×
- untagged → 1.0×

**Creature PointLights** — All 16 creature files tagged `creature_bio`: AbyssalMaw, AbyssWraith, Anglerfish, BirthSac (×2), DeepOne, FacelessOne, GhostShark, Harvester, Husk, IronWhale, Jellyfish, Leviathan, MechOctopus, RibCage, Sentinel.

**Environment** — Flora orb lights and Ocean caustic lights tagged `flora_decor`.

**AbyssEncounter** — Eye and bioluminescent lights tagged `encounter_hero`.

### Acceptance Criteria
- ✅ Player hull and headlight PointLights tagged with semantic categories at construction
- ✅ Budget traversal skips player-category lights
- ✅ Creature and flora lights categorized for priority tuning
- ✅ Existing visual behavior preserved for non-player lights (multiplicative tiebreaker, not additive)
- ✅ `npm run build` passes

Fixes #189