### PR TITLE
feat: rebalance depth-zone fog, ambient fill, and baseline lights

### DIFF
--- a/src/environment/Ocean.js
+++ b/src/environment/Ocean.js
@@ -7,14 +7,14 @@ export class Ocean {
     this.particles = [];
     this.time = 0;
 
-    // Ambient light - dim for darker atmosphere
-    this.ambientLight = new THREE.AmbientLight(0x223344, 0.2);
+    // Ambient light — richer blue fill for underwater atmosphere
+    this.ambientLight = new THREE.AmbientLight(0x2a4466, 0.22);
     scene.add(this.ambientLight);
 
     // Sun light from above (only visible near surface).
     // Dynamic shadow-map compilation was causing multi-second startup stalls
     // on the first interactive render, so keep the light shadowless.
-    this.sunLight = new THREE.DirectionalLight(0x6699aa, 0.4);
+    this.sunLight = new THREE.DirectionalLight(0x7099bb, 0.45);
     this.sunLight.position.set(50, 100, 30);
     this.sunLight.castShadow = false;
     const shadowSize = qualityManager.getSettings().shadowMapSize || 1024;

--- a/src/lighting/LightingPolicy.js
+++ b/src/lighting/LightingPolicy.js
@@ -19,24 +19,24 @@ export const DEPTH_THRESHOLDS = Object.freeze({
 export const DEPTH_ZONE_PROFILES = Object.freeze({
   fog: Object.freeze({
     colors: Object.freeze({
-      surface: 0x004b70,
-      twilight: 0x001b2b,
-      darkZone: 0x02060d,
-      abyss: 0x010408,
+      surface: 0x006b8f,
+      twilight: 0x003352,
+      darkZone: 0x081018,
+      abyss: 0x030608,
     }),
     bands: Object.freeze({
       twilight: Object.freeze({ start: 35, end: 210 }),
       darkZone: Object.freeze({ start: 170, end: 520 }),
       abyss: Object.freeze({ start: 430, end: 900 }),
     }),
-    near: Object.freeze({ surface: 5.0, twilight: 2.0, darkZone: 0.7, abyss: 0.3 }),
-    far: Object.freeze({ surface: 220, twilight: 110, darkZone: 58, abyss: 50 }),
+    near: Object.freeze({ surface: 5.0, twilight: 3.0, darkZone: 1.5, abyss: 0.5 }),
+    far: Object.freeze({ surface: 240, twilight: 160, darkZone: 85, abyss: 55 }),
   }),
   ambient: Object.freeze({
     surface: 0.24,
-    twilight: 0.12,
-    darkZone: 0.06,
-    abyss: 0.05,
+    twilight: 0.16,
+    darkZone: 0.09,
+    abyss: 0.055,
   }),
   exposure: Object.freeze({
     surface: 0.76,


### PR DESCRIPTION
Rebalance the underwater environment's depth-zone fog, ambient fill, and Ocean baseline lights so the game stays readable longer as the player descends, while preserving the horror atmosphere.

## Changes

### LightingPolicy.js `DEPTH_ZONE_PROFILES`

| Parameter | Surface | Twilight | Dark Zone | Abyss |
|---|---|---|---|---|
| **Fog color** | `0x006b8f` (richer teal) | `0x003352` (deep blue) | `0x081018` (blue-dark) | `0x030608` (trace blue) |
| **Fog far** | 240 (was 220) | 160 (was 110) | 85 (was 58) | 55 (was 50) |
| **Fog near** | 5.0 (same) | 3.0 (was 2.0) | 1.5 (was 0.7) | 0.5 (was 0.3) |
| **Ambient** | 0.24 (same) | 0.16 (was 0.12) | 0.09 (was 0.06) | 0.055 (was 0.05) |

### Ocean.js baseline lights

- **AmbientLight**: `0x2a4466` at 0.22 (was `0x223344` at 0.2) — richer blue fill
- **DirectionalLight**: `0x7099bb` at 0.45 (was `0x6699aa` at 0.4) — slightly warmer overhead

## Validation targets (flashlight OFF)

| Depth | Zone | Expected |
|---|---|---|
| 60m | Early twilight | Strong blue-green fill, terrain clear at 50m+ |
| 150m | Mid twilight | Terrain silhouette visible ~30m, distinct color |
| 280m | Dark zone | Nearby 15-20m terrain readable as silhouettes |
| 500m | Deep dark | Ominous but not black; some ambient form |
| 800m | Abyss | Near-total darkness; very faint forms at 5-10m |

Tuned against post-OutputPass sRGB-correct baseline (#186). All depth-zone values edited in the centralized `LightingPolicy.DEPTH_ZONE_PROFILES` (#188).

Fixes #184