### PR TITLE
feat: decouple hull lights from flashlight toggle

### DIFF
--- a/src/player/ExternalLightingSystem.js
+++ b/src/player/ExternalLightingSystem.js
@@ -43,6 +43,9 @@ export class ExternalLightingSystem {
     this.group = new THREE.Group();
     this.group.visible = false;
 
+    this.hullLightsGroup = new THREE.Group();
+    this.hullLightsGroup.visible = true;
+
     this._beamMaterials = [];
     this.headlights = [];
     this.hullLights = [];
@@ -107,7 +110,7 @@ export class ExternalLightingSystem {
       light.userData.baseIntensity = intensity;
       light.userData.baseRange = cfg.hullRange;
       light.userData.duwCategory = 'player_practical';
-      this.group.add(light);
+      this.hullLightsGroup.add(light);
       this.hullLights.push(light);
     }
   }

--- a/src/player/Player.js
+++ b/src/player/Player.js
@@ -48,9 +48,11 @@ export class Player {
       volumetricEnabled: this._volumetricEnabled,
     });
     this.flashlight = this.externalLighting.group;
+    this.hullLights = this.externalLighting.hullLightsGroup;
 
     this.flashlight.visible = false;
     camera.add(this.flashlight);
+    camera.add(this.hullLights);
 
     // Submarine ambient glow — visible cockpit illumination
     this.subLight = new THREE.PointLight(0x445577, 8, 65);


### PR DESCRIPTION
## Summary

Decouples the submarine's 6 hull practical lights from the flashlight toggle so they remain always-on, providing consistent local fill lighting around the submarine regardless of flashlight state.

## Root cause

`ExternalLightingSystem` placed both headlights and hull lights into a single `this.group`. `Player.js` aliased this group as `this.flashlight`, and `Game._toggleFlashlight()` toggled its visibility — hiding hull lights along with the headlights.

## Changes

**ExternalLightingSystem.js**
- Created a new `hullLightsGroup` (THREE.Group, always visible)
- Hull PointLights are now added to `hullLightsGroup` instead of `this.group`
- `setEnabled()` only toggles the headlight group (unchanged behavior)

**Player.js**
- Exposed `this.hullLights` referencing `externalLighting.hullLightsGroup`
- Added `hullLightsGroup` to the camera independently of the flashlight group
- Hull lights group starts visible and is never toggled by flashlight

## Verification

- Hull lights retain `userData.duwCategory = 'player_practical'` — confirmed the point-light budget system in `Game._refreshManagedPointLights()` already skips this category
- `npm run build` passes cleanly

Fixes #181