### PR TITLE
feat: add lighting diagnostics overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,7 +448,7 @@
     <div id="warning-text"></div>
     <div id="crosshair"></div>
     <canvas id="sonar" width="150" height="150"></canvas>
-    <div id="help-hint">[H] CONTROLS  [V] DIAGNOSTICS  [R] RESTART</div>
+    <div id="help-hint">[H] CONTROLS  [V] DIAGNOSTICS  [Shift+L] LIGHTING  [R] RESTART</div>
     <div id="creature-locator">
       <h3>Creature Locator [C]</h3>
       <div id="creature-list"></div>
@@ -463,7 +463,7 @@
       </div>
     </div>
     <div id="diagnostics-panel" role="status" aria-label="Diagnostics">
-      <h3>Diagnostics [V]</h3>
+      <h3>Diagnostics [V / Shift+L]</h3>
       <div id="diagnostics-content"></div>
     </div>
   </div>
@@ -492,6 +492,7 @@
         <div class="help-row"><span class="help-key"><kbd>0</kbd></span><span class="help-desc">Stop tracking</span></div>
         <div class="help-row"><span class="help-key"><kbd>H</kbd></span><span class="help-desc">Toggle this help</span></div>
         <div class="help-row"><span class="help-key"><kbd>V</kbd></span><span class="help-desc">Toggle diagnostics panel</span></div>
+        <div class="help-row"><span class="help-key"><kbd>Shift</kbd>+<kbd>L</kbd></span><span class="help-desc">Toggle lighting diagnostics</span></div>
         <div class="help-row"><span class="help-key"><kbd>R</kbd></span><span class="help-desc">Restart the current run</span></div>
         <div class="help-row"><span class="help-key"><kbd>Esc</kbd></span><span class="help-desc">Release mouse / Pause</span></div>
       </div>

--- a/src/Game.js
+++ b/src/Game.js
@@ -220,7 +220,7 @@ export class Game {
         return;
       }
       if (
-        e.code === "KeyV" &&
+        (e.code === "KeyV" || (e.code === "KeyL" && e.shiftKey)) &&
         (this.running || this.pauseOverlay.classList.contains("visible"))
       ) {
         this.hud.toggleDiagnostics();
@@ -919,7 +919,6 @@ export class Game {
         this.player.position,
         this.camera,
       );
-      this.hud.updateDiagnostics(this._getDiagnosticsSnapshot());
       this.hud.updateBackgroundLoading(this.preload.isDescentAssistActive());
 
       // Evaluate depth-zone base, let encounter set modifiers, then apply
@@ -963,6 +962,10 @@ export class Game {
         flashlightOn: this.flashlightOn,
         exposure: this.renderer.toneMappingExposure,
       });
+
+      if (this.hud.isDiagnosticsVisible()) {
+        this.hud.updateDiagnostics(this._getDiagnosticsSnapshot());
+      }
     } catch (err) {
       console.error("[deep-underworld] Animation frame error:", err);
     }
@@ -1056,8 +1059,45 @@ export class Game {
         y: this.player.position.y,
         z: this.player.position.z,
       },
+      lighting: this.lightingPolicy.getDiagnostics(),
+      pointLights: this._getPointLightBudgetDiagnostics(),
       graphics: this.graphicsDiagnostics,
       postProcess: this.underwaterEffect.getDiagnostics(),
+    };
+  }
+
+  _getPointLightBudgetDiagnostics() {
+    const budget = this._pointLightBudget;
+    const depthBlend = THREE.MathUtils.smoothstep(this.depth, 35, 220);
+    const maxLights = Math.round(
+      THREE.MathUtils.lerp(budget.shallowMax, budget.deepMax, depthBlend),
+    );
+    const managedCategories = {};
+    const activeCategories = {};
+    let managedCount = 0;
+    let activeCount = 0;
+
+    for (const light of budget.managedLights) {
+      if (!light.parent) continue;
+      managedCount++;
+      const category = light.userData.duwCategory ?? 'uncategorized';
+      managedCategories[category] = (managedCategories[category] ?? 0) + 1;
+
+      if ((light.userData.duwTargetIntensity ?? 0) > 0.01) {
+        activeCount++;
+        activeCategories[category] = (activeCategories[category] ?? 0) + 1;
+      }
+    }
+
+    return {
+      managedCount,
+      activeCount,
+      maxLights,
+      transitionBand: budget.transitionBand,
+      scanInterval: budget.scanInterval,
+      retargetInterval: budget.retargetInterval,
+      managedCategories,
+      activeCategories,
     };
   }
 

--- a/src/lighting/LightingPolicy.js
+++ b/src/lighting/LightingPolicy.js
@@ -81,9 +81,26 @@ export class LightingPolicy {
     this._baseFogNear = 5;
     this._baseFogFar = 300;
     this._baseAmbient = 0.24;
+    this._effectiveFogNear = 5;
+    this._effectiveFogFar = 300;
+    this._effectiveAmbient = 0.24;
 
     // Exposure state
     this._targetExposure = DEPTH_ZONE_PROFILES.exposure.surface;
+    this._lastDepth = 0;
+    this._lastFlashlightOn = false;
+    this._lastZoneName = 'surface';
+    this._lastBlends = {
+      twilight: 0,
+      darkZone: 0,
+      abyss: 0,
+    };
+    this._lastZoneWeights = {
+      surface: 1,
+      twilight: 0,
+      darkZone: 0,
+      abyss: 0,
+    };
   }
 
   /**
@@ -115,6 +132,37 @@ export class LightingPolicy {
 
   get targetExposure() {
     return this._targetExposure;
+  }
+
+  getDiagnostics() {
+    return {
+      depth: this._lastDepth,
+      flashlightOn: this._lastFlashlightOn,
+      zone: this._lastZoneName,
+      blends: {
+        ...this._lastBlends,
+      },
+      zoneWeights: {
+        ...this._lastZoneWeights,
+      },
+      fogColor: `#${this._fogColor.getHexString()}`,
+      fogNear: this._effectiveFogNear,
+      fogFar: this._effectiveFogFar,
+      ambientIntensity: this._effectiveAmbient,
+      baseProfile: {
+        fogNear: this._baseFogNear,
+        fogFar: this._baseFogFar,
+        ambient: this._baseAmbient,
+      },
+      targetExposure: this._targetExposure,
+      modifiers: Array.from(this._modifiers.entries()).map(([id, modifier]) => ({
+        id,
+        weight: THREE.MathUtils.clamp(modifier.weight ?? 0, 0, 1),
+        fogNear: modifier.fogNear,
+        fogFar: modifier.fogFar,
+        ambientIntensity: modifier.ambientIntensity,
+      })),
+    };
   }
 
   /**
@@ -162,6 +210,9 @@ export class LightingPolicy {
     fog.far = fogFar;
     sceneBackground.copy(this._fogColor);
     ambientLight.intensity = ambient;
+    this._effectiveFogNear = fogNear;
+    this._effectiveFogFar = fogFar;
+    this._effectiveAmbient = ambient;
 
     // 5. Update exposure
     this._updateExposure(depth, flashlightOn, renderer);
@@ -175,10 +226,36 @@ export class LightingPolicy {
   _evaluateBaseProfile(depth, flashlightOn) {
     const p = this.profiles;
     const bands = p.fog.bands;
+    this._lastDepth = depth;
+    this._lastFlashlightOn = flashlightOn;
 
     const twilight = THREE.MathUtils.smoothstep(depth, bands.twilight.start, bands.twilight.end);
     const darkZone = THREE.MathUtils.smoothstep(depth, bands.darkZone.start, bands.darkZone.end);
     const abyss = THREE.MathUtils.smoothstep(depth, bands.abyss.start, bands.abyss.end);
+    const zoneWeights = {
+      surface: THREE.MathUtils.clamp(1 - twilight, 0, 1),
+      twilight: THREE.MathUtils.clamp(twilight - darkZone, 0, 1),
+      darkZone: THREE.MathUtils.clamp(darkZone - abyss, 0, 1),
+      abyss: THREE.MathUtils.clamp(abyss, 0, 1),
+    };
+
+    let zoneName = 'surface';
+    let zoneWeight = zoneWeights.surface;
+    for (const [candidate, weight] of Object.entries(zoneWeights)) {
+      if (weight > zoneWeight) {
+        zoneName = candidate;
+        zoneWeight = weight;
+      }
+    }
+
+    this._lastZoneName = zoneName;
+    this._lastBlends.twilight = twilight;
+    this._lastBlends.darkZone = darkZone;
+    this._lastBlends.abyss = abyss;
+    this._lastZoneWeights.surface = zoneWeights.surface;
+    this._lastZoneWeights.twilight = zoneWeights.twilight;
+    this._lastZoneWeights.darkZone = zoneWeights.darkZone;
+    this._lastZoneWeights.abyss = zoneWeights.abyss;
 
     // Fog color
     this._colorA.set(p.fog.colors.surface);

--- a/src/shaders/UnderwaterEffect.js
+++ b/src/shaders/UnderwaterEffect.js
@@ -400,6 +400,9 @@ export class UnderwaterEffect {
     this._bloomTargetStrength = this.tuning.bloom.surfaceStrength;
     this._bloomTargetThreshold = this.tuning.bloom.surfaceThreshold;
     this._bloomTargetRadius = this.tuning.bloom.radius * 2.0;
+    this._lastDepth = 0;
+    this._lastFlashlightOn = false;
+    this._lastExposure = 0.76;
     this._rebuildScaleLadder();
     this._applyComposerScale(true);
 
@@ -649,6 +652,9 @@ export class UnderwaterEffect {
 
   _updatePassState(depth, flashlightOn, exposure) {
     this.time += 0.016;
+    this._lastDepth = depth;
+    this._lastFlashlightOn = flashlightOn;
+    this._lastExposure = exposure;
     this.underwaterPass.uniforms.time.value = this.time;
     this.underwaterPass.uniforms.depth.value = depth;
     this.underwaterPass.uniforms.exposure.value = exposure;
@@ -814,6 +820,15 @@ export class UnderwaterEffect {
   }
 
   getDiagnostics() {
+    const extinction = this.underwaterPass.uniforms.extinction.value;
+    const scatterColor = this.underwaterPass.uniforms.scatterColor.value;
+    const bloomParams = this.underwaterPass.uniforms.bloomParams.value;
+    const transmittance = {
+      r: Math.exp(-extinction.x * this._lastDepth),
+      g: Math.exp(-extinction.y * this._lastDepth),
+      b: Math.exp(-extinction.z * this._lastDepth),
+    };
+    const scatterMix = 1 - Math.exp(-this.underwaterPass.uniforms.scatterDensity.value * this._lastDepth);
     const emaPressure = this._renderEmaMs > this.tuning.performance.emergencyThresholdMs
       ? 'emergency'
       : this._renderEmaMs > this.tuning.performance.degradeThresholdMs
@@ -837,6 +852,36 @@ export class UnderwaterEffect {
       renderEmaMs: this._renderEmaMs,
       lastRenderMs: this._lastRenderMs,
       bloomSuspended: this._bloomSuspended,
+      reducedShaderMode: this._reducedShaderMode,
+      depthScaleCap: this._depthScaleCap,
+      postProcessMaxScale: this._postProcessMaxScale,
+      depth: this._lastDepth,
+      flashlightOn: this._lastFlashlightOn,
+      exposure: this._lastExposure,
+      extinction: {
+        r: extinction.x,
+        g: extinction.y,
+        b: extinction.z,
+      },
+      transmittance,
+      scatter: {
+        color: {
+          r: scatterColor.x,
+          g: scatterColor.y,
+          b: scatterColor.z,
+        },
+        density: this.underwaterPass.uniforms.scatterDensity.value,
+        mix: scatterMix,
+      },
+      bloom: {
+        mode: this._bloomPass ? 'unreal' : 'shader',
+        passEnabled: !!this._bloomPass && !this._bloomSuspended,
+        shaderStrength: bloomParams.x,
+        shaderThreshold: bloomParams.y,
+        shaderRadius: bloomParams.z,
+        passStrength: this._bloomPass?.strength ?? null,
+        passThreshold: this._bloomPass?.threshold ?? null,
+      },
       emaPressure,
       lastRenderPressure,
       renderPressure: emergency ? 'emergency' : pressured ? 'pressured' : 'normal',

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -254,6 +254,10 @@ export class HUD {
     this._diagFlashUntil.clear();
   }
 
+  isDiagnosticsVisible() {
+    return this.diagnosticsVisible;
+  }
+
   resetRuntimeState() {
     this.closeLocator();
     this.stopTracking();
@@ -289,6 +293,14 @@ export class HUD {
     const rows = [
       this._diagRow('Stall risk', snapshot.postProcess?.stallRiskLabel ?? 'Unknown', stallRiskClass),
       this._diagRow('FPS / depth', `${this._fmtNumber(snapshot.fps, 0)} FPS | ${this._fmtNumber(snapshot.depth, 0)}m | max ${this._fmtNumber(snapshot.maxDepth, 0)}m`),
+      this._diagRow('Light zone', `${this._formatZone(snapshot.lighting?.zone)} | tw ${this._fmtFixed(snapshot.lighting?.blends?.twilight, 2)} | dark ${this._fmtFixed(snapshot.lighting?.blends?.darkZone, 2)} | abyss ${this._fmtFixed(snapshot.lighting?.blends?.abyss, 2)}`),
+      this._diagRow('Fog', `${snapshot.lighting?.fogColor ?? '--'} | near ${this._fmtFixed(snapshot.lighting?.fogNear, 2)} | far ${this._fmtFixed(snapshot.lighting?.fogFar, 1)}`),
+      this._diagRow('Ambient', `${this._fmtFixed(snapshot.lighting?.ambientIntensity, 3)} | target exp ${this._fmtFixed(snapshot.lighting?.targetExposure, 2)}`),
+      this._diagRow('Underwater FX', `trans ${this._formatRgb(snapshot.postProcess?.transmittance, 2)} | scatter ${this._fmtFixed(snapshot.postProcess?.scatter?.mix, 2)} @ ${this._fmtFixed(snapshot.postProcess?.scatter?.density, 4)}`),
+      this._diagRow('Bloom mode', `${snapshot.postProcess?.bloom?.mode === 'unreal' ? 'Unreal' : 'Shader'} | ${snapshot.postProcess?.bloomSuspended ? 'suspended' : snapshot.postProcess?.bloom?.passEnabled ? 'active' : 'shader-only'}`, bloomClass),
+      this._diagRow('Light budget', `${this._fmtNumber(snapshot.pointLights?.activeCount, 0)} active / ${this._fmtNumber(snapshot.pointLights?.maxLights, 0)} budget | ${this._fmtNumber(snapshot.pointLights?.managedCount, 0)} managed`),
+      this._diagRow('Light cats', `active ${this._formatCategorySummary(snapshot.pointLights?.activeCategories)} | managed ${this._formatCategorySummary(snapshot.pointLights?.managedCategories)}`),
+      this._diagRow('Modifiers', this._formatModifierSummary(snapshot.lighting?.modifiers)),
       this._diagRow('Creatures', `${this._fmtNumber(snapshot.creaturesActive, 0)} active | ${this._fmtNumber(snapshot.queuedSpawns, 0)} queued`),
       this._diagRow('Quality', `${snapshot.qualityTier ?? 'unknown'} | ${snapshot.graphics?.context ?? 'webgl'}`),
       this._diagRow('Renderer', snapshot.graphics?.hardwareAcceleratedLabel ?? 'Unknown', rendererClass),
@@ -349,6 +361,34 @@ export class HUD {
   _fmtFixed(value, digits = 1) {
     if (!Number.isFinite(value)) return '--';
     return Number(value).toFixed(digits);
+  }
+
+  _formatZone(value) {
+    if (!value) return 'Unknown';
+    if (value === 'darkZone') return 'Dark Zone';
+    return value
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/^./, (ch) => ch.toUpperCase());
+  }
+
+  _formatRgb(value, digits = 2) {
+    if (!value) return '--/--/--';
+    return `${this._fmtFixed(value.r, digits)}/${this._fmtFixed(value.g, digits)}/${this._fmtFixed(value.b, digits)}`;
+  }
+
+  _formatCategorySummary(categories) {
+    if (!categories || Object.keys(categories).length === 0) return 'none';
+    return Object.entries(categories)
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([key, count]) => `${key}:${count}`)
+      .join(', ');
+  }
+
+  _formatModifierSummary(modifiers) {
+    if (!Array.isArray(modifiers) || modifiers.length === 0) return 'none';
+    return modifiers
+      .map((modifier) => `${modifier.id} ${this._fmtFixed(modifier.weight, 2)}`)
+      .join(', ');
   }
 
   _truncateLine(text) {


### PR DESCRIPTION
## Summary
- extend the existing HUD diagnostics panel with live lighting policy, fog, ambient, underwater FX, modifier, and point-light budget state
- expose centralized lighting and post-FX diagnostics from LightingPolicy and UnderwaterEffect instead of reconstructing the values in the HUD
- add a dedicated Shift+L shortcut while keeping V, and only build the heavier lighting snapshot while diagnostics are visible

## Validation
- npm run build

Fixes #190