### PR TITLE
feat: enable sunLight shadow-casting with pre-compiled shadow maps

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -257,6 +257,8 @@ export class Game {
       terrain: this.terrain,
       flora: this.flora,
       creatures: this.creatures,
+      scene: this.scene,
+      ocean: this.ocean,
       prepareDepthState: (depth) => {
         this.lightingPolicy.update(
           depth,

--- a/src/PreloadCoordinator.js
+++ b/src/PreloadCoordinator.js
@@ -22,13 +22,15 @@ const ENTRY_TTL_MS = 1000 * 60 * 60 * 24;
 const INDEXED_DB_SIZE_CEILING = 3 * 1024 * 1024;
 
 export class PreloadCoordinator {
-  constructor({ renderer, underwaterEffect, player, terrain, flora, creatures, prepareDepthState }) {
+  constructor({ renderer, underwaterEffect, player, terrain, flora, creatures, scene, ocean, prepareDepthState }) {
     this.renderer = renderer;
     this.underwaterEffect = underwaterEffect;
     this.player = player;
     this.terrain = terrain;
     this.flora = flora;
     this.creatures = creatures;
+    this.scene = scene;
+    this.ocean = ocean;
     this.prepareDepthState = prepareDepthState;
 
     this.state = 'idle';
@@ -394,6 +396,13 @@ export class PreloadCoordinator {
 
     await this._warmFlashlightOnceAsync();
     if (token.cancelled) return;
+
+    // Pre-compile sunLight shadow map if shadows are enabled on this tier
+    if (this.ocean && this.ocean.sunLight.castShadow) {
+      this.renderer.render(this.scene, this.player.camera);
+      await new Promise(r => requestAnimationFrame(r));
+      if (token.cancelled) return;
+    }
 
     this._gpuWarmed = true;
   }

--- a/src/environment/Ocean.js
+++ b/src/environment/Ocean.js
@@ -201,11 +201,12 @@ export class Ocean {
     scene.add(this.ambientLight);
 
     // Sun light from above (only visible near surface).
-    // Dynamic shadow-map compilation was causing multi-second startup stalls
-    // on the first interactive render, so keep the light shadowless.
+    // Shadow-map is pre-compiled during PreloadCoordinator warm-up so
+    // enabling castShadow here no longer causes a first-frame stall.
+    const tier = qualityManager.tier;
     this.sunLight = new THREE.DirectionalLight(0x7099bb, 0.45);
     this.sunLight.position.set(50, 100, 30);
-    this.sunLight.castShadow = false;
+    this.sunLight.castShadow = tier === 'high' || tier === 'ultra';
     const shadowSize = qualityManager.getSettings().shadowMapSize || 1024;
     this.sunLight.shadow.mapSize.set(shadowSize, shadowSize);
     this.sunLight.shadow.camera.near = 10;
@@ -244,9 +245,11 @@ export class Ocean {
     );
     scene.background = new THREE.Color(0x006994);
 
-    // React to quality tier changes for shadow map size
+    // React to quality tier changes for shadow map size and castShadow
     window.addEventListener("qualitychange", (e) => {
+      const newTier = e.detail.tier;
       const size = e.detail.settings.shadowMapSize || 1024;
+      this.sunLight.castShadow = newTier === 'high' || newTier === 'ultra';
       this.sunLight.shadow.mapSize.set(size, size);
       if (this.sunLight.shadow.map) {
         this.sunLight.shadow.map.dispose();


### PR DESCRIPTION
Enable `sunLight.castShadow = true` on **high** and **ultra** quality tiers, with shadow map pre-compilation during PreloadCoordinator warm-up to avoid first-frame stalls.

## Changes

### `src/environment/Ocean.js`
- Gate `sunLight.castShadow` on `high`/`ultra` tier at construction time
- Toggle `castShadow` in the `qualitychange` event listener (with shadow map dispose/reset)

### `src/PreloadCoordinator.js`
- Accept `scene` and `ocean` constructor params
- Add explicit shadow map warm-up render in `_warmGpuOnceAsync()` when castShadow is enabled

### `src/Game.js`
- Pass `scene` and `ocean` to `PreloadCoordinator` constructor

## Tier behavior
| Tier | castShadow |
|------|-----------|
| low | `false` |
| medium | `false` |
| high | `true` |
| ultra | `true` |

Fixes #233