### PR TITLE
fix: scale creature visibility budgets by quality tier

### DIFF
--- a/src/creatures/CreatureManager.js
+++ b/src/creatures/CreatureManager.js
@@ -47,6 +47,7 @@ window.addEventListener('qualitychange', (e) => {
   MAX_CREATURES = s.maxCreatures;
   DESPAWN_DISTANCE_SQ = DESPAWN_DISTANCE * DESPAWN_DISTANCE;
   CULL_DISTANCE_SQ = CULL_DISTANCE * CULL_DISTANCE;
+  CREATURE_VISIBILITY_DEPTH_BUDGETS = VISIBILITY_BUDGETS_BY_TIER[e.detail.tier] || VISIBILITY_BUDGETS_BY_TIER.high;
 });
 
 function _distSq(a, b) {
@@ -59,13 +60,13 @@ const HEAVY_FRAME_DT = 1 / 20;
 const MAX_SPAWN_BUDGET_MS = 10;
 const SPAWN_EMA_ALPHA = 0.2;
 const HEAVY_SPAWN_WARN_MS = 50;
-const CREATURE_VISIBILITY_DEPTH_BUDGETS = [
-  { depth: 80, maxVisible: 6 },
-  { depth: 160, maxVisible: 5 },
-  { depth: 260, maxVisible: 4 },
-  { depth: 380, maxVisible: 3 },
-  { depth: Infinity, maxVisible: 3 },
-];
+const VISIBILITY_BUDGETS_BY_TIER = {
+  low:    [{ depth: 80, maxVisible: 6 },  { depth: 160, maxVisible: 5 },  { depth: 260, maxVisible: 4 },  { depth: 380, maxVisible: 3 },  { depth: Infinity, maxVisible: 3 }],
+  medium: [{ depth: 80, maxVisible: 9 },  { depth: 160, maxVisible: 8 },  { depth: 260, maxVisible: 6 },  { depth: 380, maxVisible: 5 },  { depth: Infinity, maxVisible: 4 }],
+  high:   [{ depth: 80, maxVisible: 12 }, { depth: 160, maxVisible: 10 }, { depth: 260, maxVisible: 8 },  { depth: 380, maxVisible: 6 },  { depth: Infinity, maxVisible: 6 }],
+  ultra:  [{ depth: 80, maxVisible: 15 }, { depth: 160, maxVisible: 13 }, { depth: 260, maxVisible: 10 }, { depth: 380, maxVisible: 8 },  { depth: Infinity, maxVisible: 8 }],
+};
+let CREATURE_VISIBILITY_DEPTH_BUDGETS = VISIBILITY_BUDGETS_BY_TIER[qualityManager.tier] || VISIBILITY_BUDGETS_BY_TIER.high;
 
 export class CreatureManager {
   constructor(scene, options = {}) {
@@ -542,6 +543,13 @@ export class CreatureManager {
     for (const creature of this.creatures) {
       if (creature.instance?.group?.visible === false) continue;
       creature.instance.update(dt, playerPos);
+    }
+
+    // Sync invisible creature positions to prevent pop-in when they become visible
+    for (const creature of this.creatures) {
+      if (creature.instance?.group?.visible === false && creature._fPos) {
+        creature.instance.group.position.copy(creature._fPos);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

The hardcoded `CREATURE_VISIBILITY_DEPTH_BUDGETS` used the same low caps (3-6 visible creatures) regardless of quality tier, causing most creatures to be hidden even on high-end hardware.

## Changes

All changes in `src/creatures/CreatureManager.js`:

1. **Tier-scaled visibility budgets** — Replaced the single hardcoded budget array with a `VISIBILITY_BUDGETS_BY_TIER` map keyed by quality tier (`low`/`medium`/`high`/`ultra`). The old values become the `low` tier. Higher tiers allow proportionally more visible creatures (up to 15 in shallow water on `ultra`).

2. **Runtime quality switching** — The `qualitychange` event listener now also updates `CREATURE_VISIBILITY_DEPTH_BUDGETS` from the tier map, so the budget adjusts immediately when the player or auto-tiering changes quality.

3. **Invisible creature position sync** — After the visible-creature update loop, invisible creatures now have their group position synced from `_fPos`. This prevents pop-in teleportation when a creature transitions from invisible to visible.

4. **Preserved hysteresis bias** — The existing 10-unit visibility bias for already-visible creatures is unchanged.

Fixes #260