### PR TITLE
fix: retune underwater color grading for visible depth zones

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -92,7 +92,7 @@ export class Game {
       this.renderer.setPixelRatio(window.devicePixelRatio);
     }
     this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-    this.renderer.toneMappingExposure = 0.76;
+    this.renderer.toneMappingExposure = 0.85;
     this.renderer.outputColorSpace = THREE.SRGBColorSpace;
     this.renderer.domElement.id = "game-canvas";
     this.renderer.domElement.dataset.testid = "game-canvas";

--- a/src/environment/Ocean.js
+++ b/src/environment/Ocean.js
@@ -253,7 +253,7 @@ export class Ocean {
     this._particleRenderer = null;
 
     // Ambient light — richer blue fill for underwater atmosphere
-    this.ambientLight = new THREE.AmbientLight(0x2a4466, 0.22);
+    this.ambientLight = new THREE.AmbientLight(0x2a4466, 0.28);
     scene.add(this.ambientLight);
 
     // Sun light from above (only visible near surface).

--- a/src/lighting/LightingPolicy.js
+++ b/src/lighting/LightingPolicy.js
@@ -21,8 +21,8 @@ export const DEPTH_ZONE_PROFILES = Object.freeze({
     colors: Object.freeze({
       surface: 0x006b8f,
       twilight: 0x003352,
-      darkZone: 0x081018,
-      abyss: 0x030608,
+      darkZone: 0x0c1820,
+      abyss: 0x060c12,
     }),
     bands: Object.freeze({
       twilight: Object.freeze({ start: 35, end: 210 }),
@@ -49,10 +49,10 @@ export const DEPTH_ZONE_PROFILES = Object.freeze({
     abyss: 0.055,
   }),
   exposure: Object.freeze({
-    surface: 0.76,
+    surface: 0.85,
     mid: 0.7,
     deep: 0.65,
-    abyss: 0.62,
+    abyss: 0.70,
     flashlightBoost: 0.12,
     easing: 0.08,
   }),

--- a/src/shaders/UnderwaterEffect.js
+++ b/src/shaders/UnderwaterEffect.js
@@ -52,14 +52,14 @@ function cloneUniforms(uniforms) {
 const RENDER_PIPELINE_TUNING = deepFreeze({
   depthThresholds: DEPTH_THRESHOLDS,
   extinction: {
-    r: 0.22,
+    r: 0.12,
     g: 0.045,
     b: 0.014,
   },
   scatter: {
-    r: 0.012,
-    g: 0.048,
-    b: 0.075,
+    r: 0.04,
+    g: 0.12,
+    b: 0.18,
     density: 0.003,
   },
   grading: {
@@ -230,7 +230,7 @@ function createUnderwaterPostColorNode(sourceNode, uniformNodes) {
     const vignetteStrength = min(depthBlend.mul(uniformNodes.grading.y).add(0.12), 0.65);
     const vignetteDistance = dot(distortedUv.sub(0.5), distortedUv.sub(0.5));
     const vignetteMask = float(1.0).sub(smoothstep(0.12, 0.42, vignetteDistance).mul(vignetteStrength));
-    color.assign(color.mul(max(vignetteMask, 0.2)));
+    color.assign(color.mul(max(vignetteMask, 0.35)));
 
     const transmittance = exp(uniformNodes.extinction.mul(uniformNodes.depth).mul(-1.0));
     const scatterMix = float(1.0).sub(exp(uniformNodes.scatterDensity.mul(uniformNodes.depth).mul(-1.0)));


### PR DESCRIPTION
Retune the underwater post-processing pipeline so all depth zones produce visually distinct, atmospheric output instead of rendering near-black at depth.

## Changes

**UnderwaterEffect.js** — RENDER_PIPELINE_TUNING:
- Increased scatter RGB (0.012/0.048/0.075 → 0.04/0.12/0.18) for stronger underwater color
- Reduced red extinction (0.22 → 0.12) to retain more warm light at depth
- Raised vignette floor (0.2 → 0.35) to prevent over-darkening at screen edges

**LightingPolicy.js** — DEPTH_ZONE_PROFILES:
- Brightened darkZone fog color (0x081018 → 0x0c1820)
- Brightened abyss fog color (0x030608 → 0x060c12)
- Increased surface exposure (0.76 → 0.85) and abyss exposure (0.62 → 0.70)

**Game.js**:
- Matched initial toneMappingExposure to updated surface profile (0.76 → 0.85)

**Ocean.js**:
- Increased ambient light intensity (0.22 → 0.28) for richer underwater fill

Fixes #258