### PR TITLE
fix: resolve creature spawn queue starvation under frame stress

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -1048,7 +1048,7 @@ export class Game {
       const _initElapsed = performance.now() - _initStart;
       const _spawnBudget = Math.max(0, 12 - _initElapsed);
       const _descentAssistActive = this.preload.isDescentAssistActive();
-      const _effectiveSpawnBudget = _descentAssistActive ? 0 : _spawnBudget;
+      const _effectiveSpawnBudget = _descentAssistActive ? Math.min(2, _spawnBudget) : _spawnBudget;
       this.creatures.update(
         dt,
         this.player.position,

--- a/src/creatures/CreatureManager.js
+++ b/src/creatures/CreatureManager.js
@@ -497,13 +497,15 @@ export class CreatureManager {
     // prevents compounding expensive initialization operations.
     const frameIsHeavy = dt >= HEAVY_FRAME_DT;
     const cappedSpawnBudget = Math.min(MAX_SPAWN_BUDGET_MS, Math.max(0, spawnBudgetMs));
-    if (this._spawnQueue.length > 0 && cappedSpawnBudget > 1 && !frameIsHeavy && this._spawnCooldown <= 0) {
-      const drained = this.preloadDrain(QUEUE_DRAIN_PER_FRAME, undefined, depth, cappedSpawnBudget);
+    const allowLightweightSpawn = frameIsHeavy && this._spawnCostEmaMs < 8 && this._spawnCostEmaMs > 0;
+    if (this._spawnQueue.length > 0 && cappedSpawnBudget > 1 && (!frameIsHeavy || allowLightweightSpawn) && this._spawnCooldown <= 0) {
+      const drainCount = cappedSpawnBudget > 6 ? 2 : QUEUE_DRAIN_PER_FRAME;
+      const drained = this.preloadDrain(drainCount, undefined, depth, cappedSpawnBudget);
       if (drained > 0) {
         // Back off after heavy constructors so expensive spawns don't chain
         // into repeated long-frame stalls.
         if (this._lastSpawnCostMs > cappedSpawnBudget || this._spawnCostEmaMs > cappedSpawnBudget * 1.5) {
-          const cooldown = Math.min(2.5, Math.max(0.2, this._lastSpawnCostMs / 220));
+          const cooldown = Math.min(1.0, Math.max(0.2, this._lastSpawnCostMs / 220));
           this._spawnCooldown = Math.max(this._spawnCooldown, cooldown);
         }
       }


### PR DESCRIPTION
## Summary

Fixes creature spawn queue starvation that occurs under sustained frame stress, where heavy frames and aggressive cooldowns prevent the spawn queue from draining.

### Changes

1. **Allow lightweight spawns during heavy frames** — if the spawn cost EMA indicates the next spawn is cheap (<8ms), permit one spawn even on heavy frames instead of blanket-blocking all spawns.

2. **Reduce maximum cooldown from 2.5s to 1.0s** — the previous 2.5s cap caused excessive starvation windows; 1.0s still prevents back-to-back expensive spawns without starving the queue.

3. **Allow small spawn budget during descent assist** — instead of zeroing the budget entirely, allow up to 2ms so lightweight creatures can still trickle in during descent assist.

4. **Increase drain rate when budget is ample** — drain 2 creatures per frame when budget exceeds 6ms, doubling throughput when the frame has headroom.

Fixes #259