### PR TITLE
feat: add spike detection and faster auto-quality response

### DIFF
--- a/src/QualityManager.js
+++ b/src/QualityManager.js
@@ -168,7 +168,7 @@ class QualityManager {
     this._highEndGpuDetected = false;
 
     // Spike detection & anti-ping-pong state
-    this._lastTierChangeTime = 0;
+    this._lastTierChangeTime = -Infinity;
     this._spikeDowngrade = false;
   }
 
@@ -296,6 +296,7 @@ class QualityManager {
     this._downgradeDuration = 0;
     this._upgradeDuration = 0;
     this._ultraUpgradeDuration = 0;
+    this._lastTierChangeTime = performance.now();
     // Don't persist auto changes to localStorage
     window.dispatchEvent(
       new CustomEvent("qualitychange", {


### PR DESCRIPTION
Add spike detection and faster auto-quality response to QualityManager.\n\n## Changes\n\n- **Spike detection**: single frames exceeding 50ms trigger an immediate one-tier downgrade\n- **Spike recovery**: spike-only downgrades recover in 2s instead of the sustained 4s window\n- **Faster sustained response**: downgrade window reduced from 3s to 1.5s, upgrade window from 5s to 4s\n- **Anti-ping-pong cooldown**: 1.5s cooldown after any tier change prevents rapid oscillation\n- All existing behavior preserved: EMA-based sustained path, qualitychange events, tier definitions, ultra opt-in logic\n\nFixes #262