### PR TITLE
fix: retune marine snow particles and post-FX for scene readability

### DIFF
--- a/src/environment/Ocean.js
+++ b/src/environment/Ocean.js
@@ -51,7 +51,7 @@ const WATER_SURFACE_BOUNDS_PADDING =
   WATER_SURFACE_X_WAVE_AMPLITUDE + WATER_SURFACE_Z_WAVE_AMPLITUDE;
 const MARINE_SNOW_VIEW_SCALE = 165.0;
 const MARINE_SNOW_MIN_SCREEN_SIZE = 0.35;
-const MARINE_SNOW_MAX_SCREEN_SIZE = 6.0;
+const MARINE_SNOW_MAX_SCREEN_SIZE = 4.0;
 const MARINE_SNOW_TEXTURE_RESOLUTION = 48;
 
 function cloneUniformValue(value) {
@@ -287,8 +287,8 @@ export class Ocean {
     this._createWaterSurface();
 
     // Floating particles (marine snow, plankton)
-    this.particleBaseSize = 0.15;
-    this.particleBaseOpacity = 0.35;
+    this.particleBaseSize = 0.12;
+    this.particleBaseOpacity = 0.22;
     this._rebuildParticles(qualityManager.getSettings());
 
     // Caustics light cookies near surface
@@ -768,8 +768,8 @@ export class Ocean {
 
     // Deep water gets a bit denser, but avoid oversized bright discs.
     const deepOpacity = THREE.MathUtils.lerp(
-      this.particleBaseOpacity * 0.85,
-      this.particleBaseOpacity * 1.4,
+      this.particleBaseOpacity * 0.7,
+      this.particleBaseOpacity * 1.0,
       depthBlend,
     );
     const abyssFade = THREE.MathUtils.lerp(1.0, 0.9, abyssBlend);
@@ -777,8 +777,8 @@ export class Ocean {
       deepOpacity * abyssFade;
 
     const deepSize = THREE.MathUtils.lerp(
-      this.particleBaseSize * 0.95,
-      this.particleBaseSize * 1.18,
+      this.particleBaseSize * 0.85,
+      this.particleBaseSize * 1.05,
       depthBlend,
     );
     const abyssSizeClamp = THREE.MathUtils.lerp(1.0, 0.94, abyssBlend);

--- a/src/shaders/UnderwaterEffect.js
+++ b/src/shaders/UnderwaterEffect.js
@@ -64,8 +64,8 @@ const RENDER_PIPELINE_TUNING = deepFreeze({
   },
   grading: {
     contrast: 1.08,
-    vignette: 0.28,
-    grain: 0.018,
+    vignette: 0.22,
+    grain: 0.010,
     scanline: 0.0,
     eyeAdapt: 0.12,
   },
@@ -76,9 +76,9 @@ const RENDER_PIPELINE_TUNING = deepFreeze({
   },
   bloom: {
     surfaceStrength: 0.28,
-    deepStrength: 0.55,
+    deepStrength: 0.42,
     surfaceThreshold: 0.78,
-    deepThreshold: 0.58,
+    deepThreshold: 0.65,
     radius: 0.62,
   },
   performance: {
@@ -183,7 +183,7 @@ function createUnderwaterPostColorNode(sourceNode, uniformNodes) {
   return Fn(() => {
     const distortedUv = vec2(sourceUVNode).toVar();
     const lumaWeights = vec3(0.2126, 0.7152, 0.0722);
-    const distortionStrength = uniformNodes.depth.mul(0.0000055).add(0.0011);
+    const distortionStrength = uniformNodes.depth.mul(0.0000040).add(0.0009);
 
     distortedUv.assign(vec2(
       distortedUv.x.add(sin(distortedUv.y.mul(15.0).add(uniformNodes.time)).mul(distortionStrength)),
@@ -218,8 +218,8 @@ function createUnderwaterPostColorNode(sourceNode, uniformNodes) {
       const edgeDist = distance(distortedUv, vec2(0.5));
       const edgeMask = smoothstep(0.2, 0.74, edgeDist);
       const aberrationStrength = min(
-        depthBlend.mul(0.00014).add(abyssBlend.mul(0.00005)).mul(edgeMask),
-        0.00022,
+        depthBlend.mul(0.00010).add(abyssBlend.mul(0.00003)).mul(edgeMask),
+        0.00015,
       );
       const red = sourceTextureNode.sample(distortedUv.add(vec2(aberrationStrength, aberrationStrength.mul(0.3)))).r;
       const blue = sourceTextureNode.sample(distortedUv.sub(vec2(aberrationStrength, aberrationStrength.mul(0.2)))).b;
@@ -230,7 +230,7 @@ function createUnderwaterPostColorNode(sourceNode, uniformNodes) {
     const vignetteStrength = min(depthBlend.mul(uniformNodes.grading.y).add(0.12), 0.65);
     const vignetteDistance = dot(distortedUv.sub(0.5), distortedUv.sub(0.5));
     const vignetteMask = float(1.0).sub(smoothstep(0.12, 0.42, vignetteDistance).mul(vignetteStrength));
-    color.assign(color.mul(max(vignetteMask, 0.35)));
+    color.assign(color.mul(max(vignetteMask, 0.42)));
 
     const transmittance = exp(uniformNodes.extinction.mul(uniformNodes.depth).mul(-1.0));
     const scatterMix = float(1.0).sub(exp(uniformNodes.scatterDensity.mul(uniformNodes.depth).mul(-1.0)));
@@ -292,7 +292,7 @@ function createUnderwaterPostColorNode(sourceNode, uniformNodes) {
     const silhouetteLift = smoothstep(0.02, 0.25, dot(color, lumaWeights)).mul(0.028).mul(abyssBlend);
     color.addAssign(vec3(silhouetteLift));
 
-    const grainStrength = uniformNodes.grading.z.add(depthBlend.mul(0.02))
+    const grainStrength = uniformNodes.grading.z.add(depthBlend.mul(0.012))
       .mul(float(1.0).sub(uniformNodes.reducedMode.mul(0.7)));
     const grain = fract(
       sin(dot(distortedUv.mul(uniformNodes.time).mul(0.01), vec2(12.9898, 78.233))).mul(43758.5453)
@@ -302,7 +302,7 @@ function createUnderwaterPostColorNode(sourceNode, uniformNodes) {
     const dither = fract(
       fract(dot(fragCoord, vec2(0.06711056, 0.00583715)).add(uniformNodes.time.mul(0.003))).mul(52.9829189)
     );
-    const ditherStrength = mix(0.0016, 0.0065, abyssBlend)
+    const ditherStrength = mix(0.0016, 0.0040, abyssBlend)
       .mul(float(1.0).sub(uniformNodes.reducedMode.mul(0.75)));
     color.addAssign(vec3(dither.sub(0.5).mul(ditherStrength)));
 


### PR DESCRIPTION
Restore scene readability by retuning marine snow particles and post-processing effects so the gameplay frame reads as underwater space rather than noise.

## Marine Snow Particles (Ocean.js)
- Reduced `particleBaseOpacity` from 0.35 → 0.22
- Reduced depth opacity scaling max multiplier from 1.4 → 1.0, shallow from 0.85 → 0.7
- Reduced `particleBaseSize` from 0.15 → 0.12
- Reduced depth size scaling max multiplier from 1.18 → 1.05, shallow from 0.95 → 0.85
- Reduced `MARINE_SNOW_MAX_SCREEN_SIZE` from 6.0 → 4.0
- Particle counts unchanged (750/1500/2250/3000)

## Post-Processing Effects (UnderwaterEffect.js)
- **Grain**: base reduced from 0.018 → 0.010, depth addition from 0.02 → 0.012
- **Chromatic Aberration**: max cap 0.00022 → 0.00015, depth blend 0.00014 → 0.00010, abyss blend 0.00005 → 0.00003
- **Vignette**: base parameter 0.28 → 0.22, floor raised from 0.35 → 0.42
- **Bloom**: deepStrength 0.55 → 0.42, deepThreshold 0.58 → 0.65
- **Dither**: abyss dither 0.0065 → 0.0040
- **Distortion**: depth factor 0.0000055 → 0.0000040, base 0.0011 → 0.0009

All effects remain present but toned down. No features removed. Contrast, eye adaptation, and lighting policy unchanged.

Fixes #271