### PR TITLE
fix: keyboard input overrides autoplay per-axis instead of summing

### DIFF
--- a/src/player/Player.js
+++ b/src/player/Player.js
@@ -201,27 +201,14 @@ export class Player {
 
     this._accel.set(0, 0, 0);
 
-    const forwardInput = THREE.MathUtils.clamp(
-      (this.keys["KeyW"] ? 1 : 0) -
-        (this.keys["KeyS"] ? 1 : 0) +
-        this.autoplayInput.forward,
-      -1,
-      1,
-    );
-    const rightInput = THREE.MathUtils.clamp(
-      (this.keys["KeyD"] ? 1 : 0) -
-        (this.keys["KeyA"] ? 1 : 0) +
-        this.autoplayInput.right,
-      -1,
-      1,
-    );
-    const verticalInput = THREE.MathUtils.clamp(
-      (this.keys["Space"] ? 1 : 0) -
-        (this.keys["ShiftLeft"] || this.keys["ShiftRight"] ? 1 : 0) +
-        this.autoplayInput.vertical,
-      -1,
-      1,
-    );
+    const keyForward = (this.keys["KeyW"] ? 1 : 0) - (this.keys["KeyS"] ? 1 : 0);
+    const keyRight = (this.keys["KeyD"] ? 1 : 0) - (this.keys["KeyA"] ? 1 : 0);
+    const keyVertical = (this.keys["Space"] ? 1 : 0) -
+      (this.keys["ShiftLeft"] || this.keys["ShiftRight"] ? 1 : 0);
+
+    const forwardInput = keyForward !== 0 ? keyForward : this.autoplayInput.forward;
+    const rightInput = keyRight !== 0 ? keyRight : this.autoplayInput.right;
+    const verticalInput = keyVertical !== 0 ? keyVertical : this.autoplayInput.vertical;
 
     if (forwardInput !== 0)
       this._accel.addScaledVector(this._forward, forwardInput);


### PR DESCRIPTION
## Summary

Fixes #272

Replaces the summed-and-clamped input composition in `Player.update()` with per-axis keyboard-overrides-autoplay logic:

- When a keyboard key is pressed on an axis, the keyboard value is used (full override)
- When no key is pressed on an axis, autoplay controls that axis
- Values are inherently in [-1, 1] so clamping is no longer needed
- Without `?autoplay`, `autoplayInput` is always `{0,0,0}` so behavior is identical to before