### PR TITLE
fix: use separate unpatched material for SporeCloud tendrils

### DIFF
--- a/src/creatures/SporeCloud.js
+++ b/src/creatures/SporeCloud.js
@@ -143,6 +143,23 @@ export class SporeCloud {
     });
     _patchBioMaterial(sporeMat, false);
 
+    // Separate unpatched material for tendrils — tendrils don't need
+    // per-instance pulse/cascade animation (they ride their parent spore's glow).
+    const tendrilMat = new THREE.MeshPhysicalMaterial({
+      color: 0x0a2010,
+      roughness: 0.25,
+      metalness: 0.05,
+      clearcoat: 0.9,
+      clearcoatRoughness: 0.2,
+      transparent: true,
+      opacity: 0.75,
+      emissive: new THREE.Color(0x10a030),
+      emissiveIntensity: 0.5,
+      transmission: 0.3,
+      thickness: 0.5,
+    });
+    this._nearTendrilMat = tendrilMat;
+
     const coreMat = new THREE.MeshPhysicalMaterial({
       color: 0x00ff66,
       emissive: new THREE.Color(0x00dd44),
@@ -190,7 +207,7 @@ export class SporeCloud {
     this._nearCoreMesh  = coreMesh;
 
     // Tendrils: NEAR_COUNT * TENDRILS_PER_SPORE instances — one draw call
-    const tendrilMesh = new THREE.InstancedMesh(tendrilGeo, sporeMat, NEAR_COUNT * TENDRILS_PER_SPORE);
+    const tendrilMesh = new THREE.InstancedMesh(tendrilGeo, tendrilMat, NEAR_COUNT * TENDRILS_PER_SPORE);
     tendrilMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
     this._nearTendrilMesh = tendrilMesh;
 


### PR DESCRIPTION
## Summary

SporeCloud tendril `InstancedMesh` shared the patched `sporeMat` which has TSL nodes referencing `instancePulsePhase` and `instanceCascade` attributes. But `tendrilGeo` never had these attributes, causing repeated `THREE.AttributeNode` warnings at runtime.

## Changes

- Created a separate unpatched `MeshPhysicalMaterial` (`tendrilMat`) with identical visual properties to `sporeMat` but without the `_patchBioMaterial()` call
- Changed the tendril `InstancedMesh` to use `tendrilMat` instead of the patched `sporeMat`
- Stored the reference as `this._nearTendrilMat` for lifecycle management (existing `dispose()` already handles child materials generically)

Tendrils don't need per-instance pulse/cascade animation — they ride their parent spore's glow. This eliminates the attribute warnings without any visual change.

Fixes #275