### PR TITLE
perf: eliminate per-frame Vector3 allocations in creature movement hot paths

### DIFF
--- a/src/creatures/AbyssWraith.js
+++ b/src/creatures/AbyssWraith.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 
+const _tmpDir = new THREE.Vector3();
+
 // Spectral wraith of the abyss - elongated skull, trailing shadow membrane, inner jaw
 export class AbyssWraith {
   constructor(scene, position) {
@@ -155,7 +157,7 @@ export class AbyssWraith {
       }
     }
 
-    this.group.position.add(this.direction.clone().multiplyScalar(this.speed * dt));
+    this.group.position.add(_tmpDir.copy(this.direction).multiplyScalar(this.speed * dt));
 
     // Face direction
     const angle = Math.atan2(this.direction.x, this.direction.z);

--- a/src/creatures/DeepOne.js
+++ b/src/creatures/DeepOne.js
@@ -923,7 +923,7 @@ export class DeepOne {
   }
 
   getPosition() {
-    return this.group.position.clone();
+    return this.group.position;
   }
 
   dispose() {

--- a/src/creatures/FacelessOne.js
+++ b/src/creatures/FacelessOne.js
@@ -1,6 +1,9 @@
 import * as THREE from 'three';
 import { LOD_NEAR_DISTANCE, LOD_MEDIUM_DISTANCE, toStandardMaterial } from './lodUtils.js';
 
+const _tmpDir = new THREE.Vector3();
+const _tmpVec = new THREE.Vector3();
+
 const FACELESS_LOD = {
   near:   { headSegs: [32, 24], torsoSegs: [12, 8], armSegs: 8, tendrils: true, veins: true, spines: true, fingers: true },
   medium: { headSegs: [18, 14], torsoSegs: [8, 5],  armSegs: 6, tendrils: false, veins: false, spines: false, fingers: false },
@@ -277,10 +280,10 @@ export class FacelessOne {
       }
     }
 
-    this.group.position.add(this.direction.clone().multiplyScalar(this.speed * dt));
+    this.group.position.add(_tmpDir.copy(this.direction).multiplyScalar(this.speed * dt));
 
     // Face player slowly - always watching
-    const toPlayer = new THREE.Vector3().subVectors(playerPos, this.group.position);
+    const toPlayer = _tmpVec.subVectors(playerPos, this.group.position);
     const targetY = Math.atan2(toPlayer.x, toPlayer.z);
     this.group.rotation.y = THREE.MathUtils.lerp(this.group.rotation.y, targetY + Math.PI / 2, dt * 0.5);
 

--- a/src/creatures/Harvester.js
+++ b/src/creatures/Harvester.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 
+const _tmpDir = new THREE.Vector3();
+
 // Multi-armed industrial harvester - collects biomass, mechanical gripper arms
 export class Harvester {
   constructor(scene, position) {
@@ -128,7 +130,7 @@ export class Harvester {
       }
     }
 
-    this.group.position.add(this.direction.clone().multiplyScalar(this.speed * dt));
+    this.group.position.add(_tmpDir.copy(this.direction).multiplyScalar(this.speed * dt));
 
     // Face forward
     const angle = Math.atan2(this.direction.x, this.direction.z);

--- a/src/creatures/Husk.js
+++ b/src/creatures/Husk.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 
+const _tmpDir = new THREE.Vector3();
+
 // Empty biomechanical exoskeleton husk that drifts and occasionally twitches
 export class Husk {
   constructor(scene, position) {
@@ -101,7 +103,7 @@ export class Husk {
     this.twitchTimer += dt;
 
     // Very slow dead drift
-    this.group.position.add(this.direction.clone().multiplyScalar(this.speed * dt));
+    this.group.position.add(_tmpDir.copy(this.direction).multiplyScalar(this.speed * dt));
     this.group.position.y += Math.sin(this.time * 0.15) * 0.05 * dt;
 
     // Dead tumble

--- a/src/creatures/IronWhale.js
+++ b/src/creatures/IronWhale.js
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 import { LOD_NEAR_DISTANCE, LOD_MEDIUM_DISTANCE, toStandardMaterial } from './lodUtils.js';
 
+const _tmpDir = new THREE.Vector3();
+
 const WHALE_LOD = {
   near:   { bodySegs: [24, 18], dorsalPlates: 8, barnacles: 15, baleen: 12 },
   medium: { bodySegs: [14, 10], dorsalPlates: 4, barnacles: 7,  baleen: 6 },
@@ -153,7 +155,7 @@ export class IronWhale {
       this.direction.set(Math.random() - 0.5, (Math.random() - 0.5) * 0.02, Math.random() - 0.5).normalize();
     }
 
-    this.group.position.add(this.direction.clone().multiplyScalar(this.speed * dt));
+    this.group.position.add(_tmpDir.copy(this.direction).multiplyScalar(this.speed * dt));
     this.group.position.y += Math.sin(this.time * 0.2) * 0.1 * dt;
 
     // Slow majestic turn

--- a/src/creatures/RibCage.js
+++ b/src/creatures/RibCage.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 
+const _tmpDir = new THREE.Vector3();
+
 // Floating biomechanical ribcage structure with pulsing organs inside
 export class RibCage {
   constructor(scene, position) {
@@ -117,7 +119,7 @@ export class RibCage {
       this.direction.set(Math.random() - 0.5, (Math.random() - 0.5) * 0.05, Math.random() - 0.5).normalize();
     }
 
-    this.group.position.add(this.direction.clone().multiplyScalar(this.speed * dt));
+    this.group.position.add(_tmpDir.copy(this.direction).multiplyScalar(this.speed * dt));
 
     // Slow majestic rotation
     this.group.rotation.y += dt * 0.05;

--- a/src/creatures/Sentinel.js
+++ b/src/creatures/Sentinel.js
@@ -1,5 +1,8 @@
 import * as THREE from 'three';
 
+const _tmpDir = new THREE.Vector3();
+const _tmpVec = new THREE.Vector3();
+
 // Tall thin sentinel - single cyclopean eye, watches from distance, biomechanical stilt creature
 export class Sentinel {
   constructor(scene, position) {
@@ -125,10 +128,10 @@ export class Sentinel {
       this.direction.set(Math.random() - 0.5, 0, Math.random() - 0.5).normalize();
     }
 
-    this.group.position.add(this.direction.clone().multiplyScalar(this.speed * dt));
+    this.group.position.add(_tmpDir.copy(this.direction).multiplyScalar(this.speed * dt));
 
     // Always face the player (watching)
-    const toPlayer = new THREE.Vector3().subVectors(playerPos, this.group.position);
+    const toPlayer = _tmpVec.subVectors(playerPos, this.group.position);
     const targetAngle = Math.atan2(toPlayer.x, toPlayer.z);
     this.group.rotation.y = THREE.MathUtils.lerp(this.group.rotation.y, targetAngle, dt * 1);
 


### PR DESCRIPTION
## Summary

Eliminates transient `THREE.Vector3` heap allocations from creature animation hot paths by replacing per-frame `.clone()` calls with module-level pre-allocated scratch vectors.

### Changes

**`direction.clone().multiplyScalar()` → scratch vector** (7 files)
- AbyssWraith, FacelessOne, Harvester, Husk, IronWhale, RibCage, Sentinel
- Added module-level `_tmpDir` scratch vector; replaced `this.direction.clone().multiplyScalar(speed * dt)` with `_tmpDir.copy(this.direction).multiplyScalar(speed * dt)`

**`new THREE.Vector3().subVectors()` → scratch vector** (2 files)
- FacelessOne, Sentinel
- Added module-level `_tmpVec` scratch vector; replaced `new THREE.Vector3().subVectors(...)` with `_tmpVec.subVectors(...)`

**`getPosition()` returns live reference** (1 file)
- DeepOne: changed `return this.group.position.clone()` to `return this.group.position` (callers don't retain across frames)

### Validation
- `npm run build` passes

Fixes #300