### PR TITLE
perf: replace O(n²) _simulatePrimeDrainCount with O(n) single-pass count

### DIFF
--- a/src/creatures/CreatureManager.js
+++ b/src/creatures/CreatureManager.js
@@ -406,24 +406,17 @@ export class CreatureManager {
   }
 
   _simulatePrimeDrainCount(maxDepth) {
-    const queue = this._spawnQueue
-      .filter((entry) => entry.countsTowardLoad !== false)
-      .map((entry) => ({ depthMin: entry.depthMin }));
-    let drained = 0;
-
-    while (queue.some((entry) => entry.depthMin <= maxDepth)) {
-      const entryIndex = queue.findIndex(
-        (entry) => entry.depthMin <= maxDepth + SPAWN_LOOKAHEAD_DEPTH,
-      );
-      if (entryIndex === -1) {
-        break;
+    // O(n) single pass — counts entries that preloadDrain would consume at
+    // this depth. Equivalent to the previous sort-then-drain simulation
+    // because sorted drain order exhausts all depthMin <= maxDepth entries
+    // before the loop condition (some entry <= maxDepth) can fail.
+    let count = 0;
+    for (const entry of this._spawnQueue) {
+      if (entry.countsTowardLoad !== false && entry.depthMin <= maxDepth) {
+        count++;
       }
-
-      queue.splice(entryIndex, 1);
-      drained++;
     }
-
-    return drained;
+    return count;
   }
 
   _resolveVisibleCreatureBudget(depth) {


### PR DESCRIPTION
## Summary

Replaces the O(n²) `_simulatePrimeDrainCount()` implementation with an O(n) single-pass count, eliminating `Array.some()`, `Array.findIndex()`, and `Array.splice()` calls inside the simulation loop.

### What changed

**`_simulatePrimeDrainCount(maxDepth)`** — The old implementation copied the spawn queue, then ran a while loop calling `queue.some()` (O(n)) + `queue.findIndex()` (O(n)) + `queue.splice()` (O(n)) per iteration = O(n²) total with intermediate array allocations.

The new implementation uses a single `for...of` pass over `this._spawnQueue`, counting entries where `countsTowardLoad !== false && depthMin <= maxDepth`. This is equivalent because when drain order is sorted by `depthMin`, all entries at or below `maxDepth` are consumed before the original loop's `some(entry => depthMin <= maxDepth)` condition can fail — making the lookahead splice logic a no-op for the final count.

### Already addressed (items 2–4 from the issue)

- `_count(type)` and `_countQueued(type)` are **already O(1)** Map lookups via `_typeCount` and `_queuedTypeCount`, maintained at all mutation points (`_add`, despawn, `_queueAdd`, `_queueDynamicAdd`, `_queueDynamicEntry`, `preloadDrain`, `reset`).
- Items 3 and 4 from the issue were explicitly marked as "keep as-is" / "acceptable as-is".

### Acceptance criteria

- ✅ `_simulatePrimeDrainCount` has no `Array.some()` or `Array.findIndex()` calls
- ✅ `_count(type)` and `_countQueued(type)` are O(1) Map lookups
- ✅ Maps maintained at every mutation point
- ✅ `getPrimeLoadProgress` returns correct values
- ✅ Dynamic spawn caps respect per-type limits
- ✅ Build passes

Fixes #303