### PR TITLE
perf: pre-compute god-ray billboard angles, note caustic lights already removed

### DIFF
--- a/src/environment/Ocean.js
+++ b/src/environment/Ocean.js
@@ -724,8 +724,13 @@ export class Ocean {
       // Slight random tilt for variety
       mesh.rotation.z = (Math.random() - 0.5) * 0.15;
 
+      // Pre-compute the fixed billboard angle at construction time.
+      // The group origin always coincides with the camera's horizontal
+      // position, so this angle is constant per ray.
+      const _billboardAngle = Math.atan2(-mesh.position.x, -mesh.position.z);
+
       this.godRayGroup.add(mesh);
-      this.godRays.push({ mesh, mat, height });
+      this.godRays.push({ mesh, mat, height, _billboardAngle });
     }
 
     this.scene.add(this.godRayGroup);
@@ -807,10 +812,8 @@ export class Ocean {
       for (const ray of this.godRays) {
         ray.mat.uniforms.opacity.value = depthFade;
         ray.mat.uniforms.time.value = this.time;
-        // Y-axis billboard: face the camera horizontally
-        const dx = -ray.mesh.position.x; // cam local X is 0
-        const dz = -ray.mesh.position.z; // cam local Z is 0
-        ray.mesh.rotation.y = Math.atan2(dx, dz);
+        // Y-axis billboard: use pre-computed angle (no per-frame trig)
+        ray.mesh.rotation.y = ray._billboardAngle;
       }
     } else {
       this.godRayGroup.visible = false;


### PR DESCRIPTION
## Summary

Eliminates 14 per-frame `Math.atan2` calls in the god-ray update loop by pre-computing each ray's billboard angle once at construction time in `_createGodRays()`.

### Changes

- **`_createGodRays()`**: After setting each mesh's position, compute `Math.atan2(-mesh.position.x, -mesh.position.z)` and store it as `_billboardAngle` on each `godRays[]` entry.
- **`update()` god-ray loop**: Replace the per-frame `Math.atan2(dx, dz)` with `ray._billboardAngle`.

### Caustic-light loop (no longer applicable)

The issue also described a loop-invariant `causticFade` inside a `this.causticLights` loop of ~10 PointLights. That code no longer exists — the old caustic PointLights were replaced by the refraction-based `CausticPass` texture, which has no per-light JS loop. The acceptance criteria for that part are already satisfied.

### Acceptance Criteria

- [x] `Math.atan2` is not called inside any per-frame god-ray loop
- [x] Each `godRays[]` entry stores a pre-computed `_billboardAngle` set at construction
- [x] God rays still face the correct direction (formula exactly matches the original per-frame expression)
- [x] `causticFade` loop-invariant — N/A, caustic PointLights replaced by CausticPass
- [x] Caustic flicker frame-skip — N/A, no per-light JS loop remains
- [x] Build passes: `npm run build`

Fixes #304