### PR TITLE
perf: half-pair elimination for SporeCloud boid separation and cascade loops

### DIFF
--- a/src/creatures/SporeCloud.js
+++ b/src/creatures/SporeCloud.js
@@ -86,6 +86,7 @@ export class SporeCloud {
     // Tendril local offsets (relative to each spore centre) and fixed Euler rotations
     this._tendrilRelPos = new Float32Array(NEAR_COUNT * TENDRILS_PER_SPORE * 3);
     this._tendrilRot    = new Float32Array(NEAR_COUNT * TENDRILS_PER_SPORE * 3);
+    this._sepForces     = new Float32Array(NEAR_COUNT * 3); // half-pair separation accumulator
 
     this._cascadeTimer = 0;
     this._breathAmp = 0.08 + Math.random() * 0.08;
@@ -398,18 +399,25 @@ export class SporeCloud {
       this._cascade[Math.floor(Math.random() * NEAR_COUNT)] = 1.0;
     }
 
-    // Propagate to neighbours
+    // Propagate to neighbours — half-pair: each (i,j) evaluated once
     for (let i = 0; i < NEAR_COUNT; i++) {
-      if (this._cascade[i] < 0.05) continue;
-      for (let j = 0; j < NEAR_COUNT; j++) {
-        if (i === j) continue;
+      for (let j = i + 1; j < NEAR_COUNT; j++) {
+        // Skip only when BOTH participants are dim
+        if (this._cascade[i] < 0.05 && this._cascade[j] < 0.05) continue;
         const dx = this._offsets[i * 3]     - this._offsets[j * 3];
         const dy = this._offsets[i * 3 + 1] - this._offsets[j * 3 + 1];
         const dz = this._offsets[i * 3 + 2] - this._offsets[j * 3 + 2];
         const d2 = dx * dx + dy * dy + dz * dz;
         if (d2 < CASCADE_RADIUS_SQ) {
-          const t = this._cascade[i] * dt * CASCADE_SPEED * (1 - d2 / CASCADE_RADIUS_SQ);
-          this._cascade[j] = Math.min(1, this._cascade[j] + t);
+          const falloff = 1 - d2 / CASCADE_RADIUS_SQ;
+          // i → j
+          if (this._cascade[i] >= 0.05) {
+            this._cascade[j] = Math.min(1, this._cascade[j] + this._cascade[i] * dt * CASCADE_SPEED * falloff);
+          }
+          // j → i
+          if (this._cascade[j] >= 0.05) {
+            this._cascade[i] = Math.min(1, this._cascade[i] + this._cascade[j] * dt * CASCADE_SPEED * falloff);
+          }
         }
       }
     }
@@ -425,32 +433,43 @@ export class SporeCloud {
   }
 
   _updateBoids(dt) {
+    const BOID_SEP_RADIUS_SQ = BOID_SEP_RADIUS * BOID_SEP_RADIUS;
+    const sep = this._sepForces;
+    sep.fill(0);
+
+    // Half-pair separation: each (i,j) evaluated once, equal/opposite force
     for (let i = 0; i < NEAR_COUNT; i++) {
       const ix = this._offsets[i * 3];
       const iy = this._offsets[i * 3 + 1];
       const iz = this._offsets[i * 3 + 2];
-      let sx = 0, sy = 0, sz = 0;
-
-      for (let j = 0; j < NEAR_COUNT; j++) {
-        if (i === j) continue;
+      for (let j = i + 1; j < NEAR_COUNT; j++) {
         const dx = ix - this._offsets[j * 3];
         const dy = iy - this._offsets[j * 3 + 1];
         const dz = iz - this._offsets[j * 3 + 2];
         const d2 = dx * dx + dy * dy + dz * dz;
-        if (d2 < BOID_SEP_RADIUS * BOID_SEP_RADIUS && d2 > 1e-4) {
+        if (d2 < BOID_SEP_RADIUS_SQ && d2 > 1e-4) {
           const d = Math.sqrt(d2);
           const f = (BOID_SEP_RADIUS - d) / BOID_SEP_RADIUS;
-          sx += (dx / d) * f;
-          sy += (dy / d) * f;
-          sz += (dz / d) * f;
+          const fx = (dx / d) * f;
+          const fy = (dy / d) * f;
+          const fz = (dz / d) * f;
+          sep[i * 3]     += fx; sep[i * 3 + 1] += fy; sep[i * 3 + 2] += fz;
+          sep[j * 3]     -= fx; sep[j * 3 + 1] -= fy; sep[j * 3 + 2] -= fz;
         }
       }
-
-      // Cohesion: pull toward cloud centre (origin of local space)
-      this._velocities[i * 3]     = this._velocities[i * 3]     * BOID_DRAG + (sx * BOID_SEP_FORCE - ix * BOID_COHESION_FORCE) * dt;
-      this._velocities[i * 3 + 1] = this._velocities[i * 3 + 1] * BOID_DRAG + (sy * BOID_SEP_FORCE - iy * BOID_COHESION_FORCE) * dt;
-      this._velocities[i * 3 + 2] = this._velocities[i * 3 + 2] * BOID_DRAG + (sz * BOID_SEP_FORCE - iz * BOID_COHESION_FORCE) * dt;
     }
+
+    // Apply drag, separation, and cohesion
+    for (let i = 0; i < NEAR_COUNT; i++) {
+      const ix = this._offsets[i * 3];
+      const iy = this._offsets[i * 3 + 1];
+      const iz = this._offsets[i * 3 + 2];
+      this._velocities[i * 3]     = this._velocities[i * 3]     * BOID_DRAG + (sep[i * 3]     * BOID_SEP_FORCE - ix * BOID_COHESION_FORCE) * dt;
+      this._velocities[i * 3 + 1] = this._velocities[i * 3 + 1] * BOID_DRAG + (sep[i * 3 + 1] * BOID_SEP_FORCE - iy * BOID_COHESION_FORCE) * dt;
+      this._velocities[i * 3 + 2] = this._velocities[i * 3 + 2] * BOID_DRAG + (sep[i * 3 + 2] * BOID_SEP_FORCE - iz * BOID_COHESION_FORCE) * dt;
+    }
+
+    // Integrate positions
     for (let i = 0; i < NEAR_COUNT; i++) {
       this._offsets[i * 3]     += this._velocities[i * 3]     * dt;
       this._offsets[i * 3 + 1] += this._velocities[i * 3 + 1] * dt;


### PR DESCRIPTION
## Summary

Reduces the O(n²) pair-evaluation cost in `SporeCloud._updateBoids()` and `SporeCloud._updateCascade()` from ~1,560 pairs (40×39) to 780 pairs using half-pair elimination (Newton's third law symmetry).

### Changes

**`_updateBoids`**: Inner loop changed from `j = 0..N, skip i===j` to `j = i+1..N`. Each pair is evaluated once; equal and opposite separation forces are applied to both particles simultaneously via a pre-allocated `_sepForces` accumulator buffer. Drag, cohesion, and position integration are applied in separate passes afterward.

**`_updateCascade`**: Inner loop changed from `j = 0..N, skip i===j` to `j = i+1..N`. The outer-loop early-out (`cascade[i] < 0.05`) is replaced with a pair-level guard that skips only when **both** participants are dim, preserving bidirectional luminescence spreading.

**Constructor**: Added `_sepForces` Float32Array (NEAR_COUNT × 3) — zero per-frame allocation.

### Verification

- Build passes (`npm run build`).
- Boid separation force computation is mathematically equivalent (symmetric force pairs).
- Cascade propagation preserves bidirectional spreading behavior.
- No self-pair evaluation (i === j) in either loop.

Fixes #307