### PR TITLE
perf: eliminate per-frame computeVertexNormals/computeBoundingSphere from VoidJelly

### DIFF
--- a/src/creatures/VoidJelly.js
+++ b/src/creatures/VoidJelly.js
@@ -346,6 +346,10 @@ export class VoidJelly {
       rootX += rest[i]; rootZ += rest[i + 2]; rootCount++;
     }
 
+    // One-time bounding sphere — padded to cover deformation range
+    geom.computeBoundingSphere();
+    geom.boundingSphere.radius *= 1.5;
+
     return {
       mesh, geometry: geom, restPositions: rest,
       rootCenter: {
@@ -408,9 +412,6 @@ export class VoidJelly {
     }
 
     positions.needsUpdate = true;
-    app.geometry.computeVertexNormals();
-    app.geometry.attributes.normal.needsUpdate = true;
-    app.geometry.computeBoundingSphere();
   }
 
   // ─── Oral arms — TubeGeometry with ruffled edges (CatmullRomCurve3) ────────
@@ -456,6 +457,7 @@ export class VoidJelly {
         thickness: 0.25,
         side: THREE.DoubleSide,
         depthWrite: false,
+        flatShading: true,
       });
       const mesh = new THREE.Mesh(armGeo, armMat);
       group.add(mesh);
@@ -480,6 +482,7 @@ export class VoidJelly {
         transmission: 0.18,
         side: THREE.DoubleSide,
         depthWrite: false,
+        flatShading: true,
       });
       const frill = new THREE.Mesh(frillGeo, frillMat);
       group.add(frill);
@@ -549,6 +552,7 @@ export class VoidJelly {
         transparent: true, opacity: 0.32,
         roughness: 0.28,
         depthWrite: false,
+        flatShading: true,
       });
       const mesh = new THREE.Mesh(tentGeo, tentMat);
       group.add(mesh);
@@ -601,6 +605,7 @@ export class VoidJelly {
         transparent: true, opacity: 0.28,
         roughness: 0.3,
         depthWrite: false,
+        flatShading: true,
       });
       const mesh = new THREE.Mesh(geo, mat);
       group.add(mesh);


### PR DESCRIPTION
## Summary

Eliminates 88 full-mesh traversals per frame from VoidJelly's near-tier appendage deformation by removing per-frame `computeVertexNormals()` and `computeBoundingSphere()` calls.

### Changes

1. **Removed `computeBoundingSphere()` from `_deformAppendage()`** — now computed once in `_createAppendageDescriptor()` with a 1.5× radius padding to safely cover the deformation range without premature frustum culling.

2. **Removed `computeVertexNormals()` from `_deformAppendage()`** — replaced with `flatShading: true` on all four appendage material types (oral arms, oral arm frills, tentacles, marginal tentacles). In Three.js WebGPU, flat shading computes normals from screen-space derivatives in the fragment shader at zero CPU cost. This is visually appropriate for VoidJelly's translucent soft-body appendages.

### Materials updated with `flatShading: true`
- Oral arm material
- Oral arm frill material
- Tentacle material
- Marginal tentacle material

Fixes #301