### PR TITLE
perf: eliminate redundant trig and sqrt in creature animation hot paths

### DIFF
--- a/src/creatures/Amalgam.js
+++ b/src/creatures/Amalgam.js
@@ -23,6 +23,9 @@ const _webTemp = new THREE.Vector3();
 
 const TWO_PI = Math.PI * 2;
 const RESPAWN_DISTANCE = 200;
+const RESPAWN_DISTANCE_SQ = RESPAWN_DISTANCE * RESPAWN_DISTANCE;
+const PROXIMITY_RANGE = 40;
+const PROXIMITY_RANGE_SQ = PROXIMITY_RANGE * PROXIMITY_RANGE;
 const WEB_TUBULAR_SEGMENTS = 8;
 const WEB_RADIAL_SEGMENTS = 4;
 const WEB_RADIUS = 0.016;
@@ -877,9 +880,10 @@ export class Amalgam {
     // Breathing phase drives near-tier deformation and medium/far glow timing.
     this._breathPhase += dt * 1.2;
 
-    // Player proximity factor
-    const distToPlayer = Math.sqrt(distSq);
-    const targetProx = THREE.MathUtils.clamp(1 - distToPlayer / 40, 0, 1);
+    // Player proximity factor — uses squared distance to avoid sqrt
+    const targetProx = distSq < PROXIMITY_RANGE_SQ
+      ? THREE.MathUtils.clamp(1 - Math.sqrt(distSq) / PROXIMITY_RANGE, 0, 1)
+      : 0;
     this._proximityFactor +=
       (targetProx - this._proximityFactor) * Math.min(1, dt * 2);
 
@@ -1064,8 +1068,8 @@ export class Amalgam {
       }
     }
 
-    // Respawn if too far
-    if (distToPlayer > RESPAWN_DISTANCE) {
+    // Respawn if too far (squared comparison avoids sqrt)
+    if (distSq > RESPAWN_DISTANCE_SQ) {
       const a = Math.random() * TWO_PI;
       this.group.position.set(
         playerPos.x + Math.cos(a) * 80,

--- a/src/creatures/BioMechCrab.js
+++ b/src/creatures/BioMechCrab.js
@@ -13,6 +13,22 @@ let _spineGeo = null;
 const TWO_PI = Math.PI * 2;
 const HALF_PI = Math.PI * 0.5;
 
+// ── Fast acos lookup table (64-entry, linear interpolation over [-1, 1] → [0, π]) ──
+const ACOS_TABLE_SIZE = 64;
+const ACOS_TABLE = new Float32Array(ACOS_TABLE_SIZE + 1);
+for (let i = 0; i <= ACOS_TABLE_SIZE; i++) {
+  ACOS_TABLE[i] = Math.acos(2 * i / ACOS_TABLE_SIZE - 1);
+}
+
+function fastAcos(x) {
+  // Clamp to [-1, 1] and map to [0, ACOS_TABLE_SIZE]
+  const t = (Math.min(1, Math.max(-1, x)) + 1) * 0.5 * ACOS_TABLE_SIZE;
+  const i = t | 0; // floor
+  if (i >= ACOS_TABLE_SIZE) return ACOS_TABLE[ACOS_TABLE_SIZE];
+  const f = t - i;
+  return ACOS_TABLE[i] * (1 - f) + ACOS_TABLE[i + 1] * f;
+}
+
 function _hash(x, y, seed) {
   let h = seed | 0;
   h = ((h ^ ((x | 0) * 374761393)) >>> 0) * 1103515245;
@@ -592,11 +608,11 @@ export class BioMechCrab {
 
       // Law of cosines for knee angle
       const cosKnee = (upperLen * upperLen + lowerLen * lowerLen - clampedDist * clampedDist) / (2 * upperLen * lowerLen);
-      const kneeAngle = Math.acos(THREE.MathUtils.clamp(cosKnee, -1, 1));
+      const kneeAngle = fastAcos(cosKnee);
 
       // Hip angle
       const cosHip = (upperLen * upperLen + clampedDist * clampedDist - lowerLen * lowerLen) / (2 * upperLen * clampedDist);
-      const hipOffset = Math.acos(THREE.MathUtils.clamp(cosHip, -1, 1));
+      const hipOffset = fastAcos(cosHip);
       const targetAngle = Math.atan2(dx, -dy);
       const hipAngle = targetAngle + hipOffset * side;
 

--- a/src/creatures/ChainDragger.js
+++ b/src/creatures/ChainDragger.js
@@ -496,14 +496,16 @@ export class ChainDragger {
 
       // Distance constraint solver — enforce LINK_SPACING * scale rest length
       const restLen = LINK_SPACING * scale;
+      const restLenSq = restLen * restLen;
       for (let iter = 0; iter < SOLVE_ITERS; iter++) {
         // Root–first free particle: only move the free end (root is pinned)
         {
           const i1 = 3; // particle index 1 in world-space pos array (1 particle × 3 floats)
           const dx = pos[i1] - rx, dy = pos[i1+1] - ry, dz = pos[i1+2] - rz;
-          const dist = Math.sqrt(dx*dx + dy*dy + dz*dz);
-          if (dist > 1e-6) {
-            const corr = (dist - restLen) / dist;
+          const distSq = dx*dx + dy*dy + dz*dz;
+          if (distSq > 1e-12) {
+            // Linearised constraint: avoids sqrt for near-rest-length chains
+            const corr = (distSq - restLenSq) / (distSq + restLenSq);
             pos[i1]   -= dx * corr;
             pos[i1+1] -= dy * corr;
             pos[i1+2] -= dz * corr;
@@ -515,9 +517,10 @@ export class ChainDragger {
           const dx = pos[i1]   - pos[i0];
           const dy = pos[i1+1] - pos[i0+1];
           const dz = pos[i1+2] - pos[i0+2];
-          const dist = Math.sqrt(dx*dx + dy*dy + dz*dz);
-          if (dist < 1e-6) continue;
-          const corr = (dist - restLen) / dist * CONSTRAINT_RELAX;
+          const distSq = dx*dx + dy*dy + dz*dz;
+          if (distSq < 1e-12) continue;
+          // Linearised constraint: avoids sqrt for near-rest-length chains
+          const corr = (distSq - restLenSq) / (distSq + restLenSq) * CONSTRAINT_RELAX;
           pos[i0]   += dx * corr;
           pos[i0+1] += dy * corr;
           pos[i0+2] += dz * corr;

--- a/src/creatures/SpinalEel.js
+++ b/src/creatures/SpinalEel.js
@@ -5,6 +5,18 @@ import { qualityManager } from '../QualityManager.js';
 const TWO_PI = Math.PI * 2;
 const HALF_PI = Math.PI * 0.5;
 const RESPAWN_DISTANCE = 220;
+
+// ── Fast sin/cos lookup table (360-entry, built once) ─────────────────────────
+const SIN_TABLE_SIZE = 360;
+const SIN_INV_STEP = SIN_TABLE_SIZE / TWO_PI;
+const SIN_TABLE = new Float32Array(SIN_TABLE_SIZE);
+for (let i = 0; i < SIN_TABLE_SIZE; i++) SIN_TABLE[i] = Math.sin(i / SIN_INV_STEP);
+
+function fastSin(rad) {
+  const idx = ((Math.round(rad * SIN_INV_STEP) % SIN_TABLE_SIZE) + SIN_TABLE_SIZE) % SIN_TABLE_SIZE;
+  return SIN_TABLE[idx];
+}
+function fastCos(rad) { return fastSin(rad + HALF_PI); }
 const NEAR_DISTANCE = 30;
 const MEDIUM_DISTANCE = 80;
 const PLAYER_REACTION_DISTANCE = 30;
@@ -818,7 +830,7 @@ export class SpinalEel {
 
     const isNear = tierName === 'near';
     const isFar = tierName === 'far';
-    const swimPulse = 0.72 + (Math.sin(this.time * 3.4 + this._phaseOffset) * 0.5 + 0.5) * 0.55;
+    const swimPulse = 0.72 + (fastSin(this.time * 3.4 + this._phaseOffset) * 0.5 + 0.5) * 0.55;
     const coilStrength = this._coilState * (isNear ? 0.24 : isFar ? 0.12 : 0.16) * this._coilBias;
     const amplitude = (isNear ? 0.18 : isFar ? 0.085 : 0.13) * this._ampVariation * (0.85 + this._proximity * 0.55);
     const rotAmplitude = (isNear ? 0.24 : isFar ? 0.12 : 0.18) * (0.8 + this._proximity * 0.4);
@@ -844,25 +856,25 @@ export class SpinalEel {
     if (!tier) return;
 
     const isNear = tierName === 'near';
-    const breath = Math.sin(this.time * (1.1 + this._idleBias * 0.2) + this._breathingPhase) * 0.03;
+    const breath = fastSin(this.time * (1.1 + this._idleBias * 0.2) + this._breathingPhase) * 0.03;
     const jawTarget = distToPlayer < JAW_REACTION_DISTANCE
       ? THREE.MathUtils.clamp(1 - distToPlayer / JAW_REACTION_DISTANCE, 0, 1) * 0.85
-      : 0.14 + Math.sin(this.time * 1.7 + this._phaseOffset) * 0.06;
+      : 0.14 + fastSin(this.time * 1.7 + this._phaseOffset) * 0.06;
 
     this._jawAngle = THREE.MathUtils.lerp(this._jawAngle, jawTarget, dt * 4.5);
     this._skullTilt = THREE.MathUtils.lerp(this._skullTilt, jawTarget * 0.18 + breath * 0.8, dt * 3.8);
 
     tier.headPivot.rotation.z = -this._skullTilt;
-    tier.headPivot.rotation.y = Math.sin(this.time * 1.1 + this._phaseOffset) * 0.08 + this._coilState * 0.18 * this._coilBias;
+    tier.headPivot.rotation.y = fastSin(this.time * 1.1 + this._phaseOffset) * 0.08 + this._coilState * 0.18 * this._coilBias;
     tier.jawPivot.rotation.z = this._jawAngle;
-    tier.jawPivot.rotation.y = Math.sin(this.time * 2.0 + this._phaseOffset) * 0.06;
+    tier.jawPivot.rotation.y = fastSin(this.time * 2.0 + this._phaseOffset) * 0.06;
 
     for (let i = 0; i < tier.nodes.length; i++) {
       const node = tier.nodes[i];
       const progress = node.userData.progress;
       const phase = this.time * (4.1 * this._freqVariation) - progress * 9.8 + this._phaseOffset;
-      const wave = Math.sin(phase);
-      const crossWave = Math.cos(phase * 0.76 + this._coilBias * 0.7);
+      const wave = fastSin(phase);
+      const crossWave = fastCos(phase * 0.76 + this._coilBias * 0.7);
       const inertia = 1 - progress * 0.42;
       const baseX = -progress * tier.profile.length;
       const lateralAmp = (0.12 + progress * 0.62) * this._ampVariation * (0.75 + this._proximity * 0.45);
@@ -872,31 +884,31 @@ export class SpinalEel {
 
       node.position.set(
         baseX,
-        wave * lateralAmp + Math.sin(coilPhase) * coilEnvelope * 0.55,
-        crossWave * verticalAmp + Math.cos(coilPhase) * coilEnvelope * 0.72
+        wave * lateralAmp + fastSin(coilPhase) * coilEnvelope * 0.55,
+        crossWave * verticalAmp + fastCos(coilPhase) * coilEnvelope * 0.72
       );
       node.rotation.set(
         crossWave * (isNear ? 0.12 : 0.08) * inertia,
-        wave * (isNear ? 0.34 : 0.22) * inertia + Math.sin(coilPhase) * this._coilState * 0.18,
-        wave * 0.08 * (0.4 + progress) + Math.cos(coilPhase) * this._coilState * 0.1
+        wave * (isNear ? 0.34 : 0.22) * inertia + fastSin(coilPhase) * this._coilState * 0.18,
+        wave * 0.08 * (0.4 + progress) + fastCos(coilPhase) * this._coilState * 0.1
       );
 
-      const bulge = 1 + Math.sin(this.time * 3.25 - progress * 18 + this._phaseOffset) * (isNear ? 0.08 : 0.04) + (1 + breath) * 0.015;
+      const bulge = 1 + fastSin(this.time * 3.25 - progress * 18 + this._phaseOffset) * (isNear ? 0.08 : 0.04) + (1 + breath) * 0.015;
       node.scale.set(1, bulge, bulge * (1 + this._coilState * 0.08));
     }
 
     for (let i = 0; i < tier.fins.length; i++) {
       const fin = tier.fins[i];
-      fin.rotation.z = Math.sin(this.time * 7.2 + i * 0.75 + this._flutterOffset) * (isNear ? 0.18 : 0.09);
-      fin.rotation.x = Math.cos(this.time * 4.2 + i * 0.6) * 0.06;
-      fin.scale.y = 0.92 + Math.sin(this.time * 3.2 + i * 0.5) * (isNear ? 0.12 : 0.05);
+      fin.rotation.z = fastSin(this.time * 7.2 + i * 0.75 + this._flutterOffset) * (isNear ? 0.18 : 0.09);
+      fin.rotation.x = fastCos(this.time * 4.2 + i * 0.6) * 0.06;
+      fin.scale.y = 0.92 + fastSin(this.time * 3.2 + i * 0.5) * (isNear ? 0.12 : 0.05);
     }
 
     const tailPhase = this.time * (4.4 * this._freqVariation) + this._phaseOffset;
-    const powerStroke = Math.sin(tailPhase);
+    const powerStroke = fastSin(tailPhase);
     const asymmetricStroke = powerStroke > 0 ? powerStroke * 0.65 : powerStroke * 1.18;
     tier.tailFin.rotation.z = asymmetricStroke * 0.55 + this._coilState * 0.28;
-    tier.tailFin.rotation.x = Math.cos(tailPhase * 0.8) * 0.14;
+    tier.tailFin.rotation.x = fastCos(tailPhase * 0.8) * 0.14;
     tier.tailFin.scale.y = 1 + Math.abs(asymmetricStroke) * 0.12;
 
     for (let i = 0; i < tier.tailRays.length; i++) {
@@ -906,13 +918,13 @@ export class SpinalEel {
     }
 
     for (let i = 0; i < tier.ribs.length; i++) {
-      tier.ribs[i].rotation.x = Math.sin(this.time * 2.6 + i * 0.7) * 0.05;
-      tier.ribs[i].scale.y = 1 + Math.sin(this.time * 3.0 - i * 0.55) * 0.06;
+      tier.ribs[i].rotation.x = fastSin(this.time * 2.6 + i * 0.7) * 0.05;
+      tier.ribs[i].scale.y = 1 + fastSin(this.time * 3.0 - i * 0.55) * 0.06;
     }
 
     for (let i = 0; i < tier.dorsalProcesses.length; i++) {
-      tier.dorsalProcesses[i].scale.y = 1 + Math.sin(this.time * 3.8 - i * 0.7) * 0.12 * (isNear ? 1 : 0.45);
-      tier.dorsalProcesses[i].rotation.z = Math.sin(this.time * 4.2 - i * 0.45) * 0.08;
+      tier.dorsalProcesses[i].scale.y = 1 + fastSin(this.time * 3.8 - i * 0.7) * 0.12 * (isNear ? 1 : 0.45);
+      tier.dorsalProcesses[i].rotation.z = fastSin(this.time * 4.2 - i * 0.45) * 0.08;
     }
   }
 

--- a/src/creatures/TendrilHunter.js
+++ b/src/creatures/TendrilHunter.js
@@ -257,6 +257,9 @@ export class TendrilHunter {
     // Medium-tier tendril refs for sinusoidal sway
     this._mediumTendrilData = []; // [{group, phase}]
 
+    // Cached inverse world matrix — updated once per frame in update()
+    this._worldInverseMatrix = new THREE.Matrix4();
+
     this._buildModel();
     this.group.position.copy(position);
     scene.add(this.group);
@@ -617,6 +620,11 @@ export class TendrilHunter {
     const yaw = Math.atan2(this.direction.x, this.direction.z);
     this.group.rotation.y = THREE.MathUtils.lerp(this.group.rotation.y, yaw, dt * 3);
 
+    // Refresh world matrix after movement and cache its inverse for
+    // _animateNear() so worldToLocal no longer needs updateMatrixWorld.
+    this.group.updateMatrixWorld(true);
+    this._worldInverseMatrix.copy(this.group.matrixWorld).invert();
+
     // Respawn when too far from player; recompute distance after reposition
     // so the rest of this frame's state/animation reflects actual position.
     let distToPlayer = Math.sqrt(distSq);
@@ -628,6 +636,9 @@ export class TendrilHunter {
         playerPos.z + Math.sin(a) * 70
       );
       distToPlayer = this.group.position.distanceTo(playerPos);
+      // Re-cache world inverse after repositioning
+      this.group.updateMatrixWorld(true);
+      this._worldInverseMatrix.copy(this.group.matrixWorld).invert();
     }
 
     // ── Resolve active LOD tier ───────────────────────────────────────────────
@@ -708,11 +719,9 @@ export class TendrilHunter {
 
     // Player position in this.group's local space
     // (tierGroup / LOD have no transform, so group-local == tier-local)
-    // updateMatrixWorld ensures this frame's position/rotation changes are
-    // reflected before converting coordinates (avoids one-frame-stale IK targets).
-    this.group.updateMatrixWorld(true);
-    _v3B.copy(playerPos);
-    this.group.worldToLocal(_v3B);
+    // World inverse matrix is pre-computed in update() after movement,
+    // so we skip the expensive updateMatrixWorld(true) call here.
+    _v3B.copy(playerPos).applyMatrix4(this._worldInverseMatrix);
 
     // ── Independent mandible articulation ─────────────────────────────────────
     if (this._leftMandible && this._rightMandible) {


### PR DESCRIPTION
## Summary

Eliminates per-frame `Math.atan2`, `Math.acos`, `Math.sin`/`Math.cos` and `Math.sqrt` calls from hot creature animation paths by replacing them with lookup tables, cached values, and approximations.

### Changes by creature

**SpinalEel** — 360-entry `Float32Array` sin lookup table (`fastSin`/`fastCos`) with double-modulo negative-phase guard. Replaces all `Math.sin`/`Math.cos` in the 120-node spine loop, fin flutter, rib breathing, dorsal processes, tail power stroke, head/jaw, and uniform updates.

**TendrilHunter** — Caches the inverse world matrix once per frame in `update()` after movement. `_animateNear()` now uses the cached inverse via `applyMatrix4()` instead of calling `updateMatrixWorld(true)` + `worldToLocal()`.

**ChainDragger** — Linearised distance-constraint approximation `(distSq - restLenSq) / (distSq + restLenSq)` replaces `Math.sqrt` in all Verlet constraint solver iterations (root-to-first and interior pairs, × 4 solver iters per step).

**BioMechCrab** — 64-entry acos lookup table with linear interpolation (`fastAcos`) replaces `Math.acos` per-leg per-frame in the 2-bone IK gait solver.

**Amalgam** — Squared-distance comparisons for proximity range check and respawn distance check. `Math.sqrt` is only called when the player is actually within proximity range (typically 0–2 times per frame).

### Not changed

**Leviathan** — The issue mentioned a FABRIK spine with `distanceTo` in a segment-length guard, but the current Leviathan uses simple sine/cos segment undulation with no FABRIK solver or sqrt-based distance guards. No optimization applicable.

### Validation

- `npm run build` passes
- All creature visuals preserved (lookup precision is ≤1° for sin/cos, linear-interpolated for acos)

Fixes #306