### PR TITLE
feat: configure TypeScript for JSDoc type-checking without migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "three": "^0.183.2"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "chrome-devtools-mcp": "^0.20.3",
         "eslint": "^10.1.0",
+        "globals": "^17.4.0",
         "lighthouse": "^13.0.3",
         "stats-gl": "^4.1.0",
         "typescript": "^6.0.2",
@@ -144,6 +146,27 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -2438,6 +2461,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -11,15 +11,18 @@
     "generate:preload-lookup": "node scripts/generate-preload-lookup-artifact.mjs",
     "prebuild": "npm run generate:preload-lookup",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "npx tsc --noEmit"
   },
   "dependencies": {
     "@dimforge/rapier3d-compat": "^0.19.3",
     "three": "^0.183.2"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "chrome-devtools-mcp": "^0.20.3",
     "eslint": "^10.1.0",
+    "globals": "^17.4.0",
     "lighthouse": "^13.0.3",
     "stats-gl": "^4.1.0",
     "typescript": "^6.0.2",

--- a/src/Game.js
+++ b/src/Game.js
@@ -19,6 +19,7 @@ const DEFAULT_RENDERER_OPTIONS = Object.freeze({
 });
 
 async function resolveRendererOptions() {
+  /** @type {Record<string, any>} */
   const rendererOptions = { ...DEFAULT_RENDERER_OPTIONS };
 
   if (typeof navigator === "undefined") {
@@ -31,10 +32,10 @@ async function resolveRendererOptions() {
   }
 
   try {
-    const adapter = await navigator.gpu.requestAdapter({
+    const adapter = await navigator.gpu.requestAdapter(/** @type {*} */ ({
       powerPreference: rendererOptions.powerPreference,
       featureLevel: "compatibility",
-    });
+    }));
 
     if (!adapter) {
       rendererOptions.forceWebGL = true;
@@ -170,7 +171,7 @@ export class Game {
     this.creatureManager = this.creatures;
 
     // Quality tier change listener
-    window.addEventListener("qualitychange", (e) => {
+    window.addEventListener("qualitychange", (/** @type {CustomEvent} */ e) => {
       const s = e.detail.settings;
       const tier = e.detail.tier;
       this.renderer.shadowMap.enabled = s.shadowMapEnabled;
@@ -396,7 +397,7 @@ export class Game {
       }
     });
 
-    this.player.onLockChange = (locked) => {
+    /** @type {any} */ (this.player).onLockChange = (locked) => {
       if (locked) {
         if (this.pendingStart && !this.gameOver) {
           this._beginGameplay();
@@ -698,7 +699,7 @@ export class Game {
     }
   }
 
-  async _warmOpeningFrames({ onProgress } = {}) {
+  async _warmOpeningFrames({ onProgress } = /** @type {any} */ ({})) {
     const requiredResponsiveFrames = 6;
     let responsiveFrames = 0;
     for (let i = 0; i < 180; i++) {

--- a/src/PreloadCoordinator.js
+++ b/src/PreloadCoordinator.js
@@ -161,7 +161,7 @@ export class PreloadCoordinator {
     return this._descentAssist.active;
   }
 
-  async primeStartBaseline({ onProgress } = {}) {
+  async primeStartBaseline({ onProgress } = /** @type {any} */ ({})) {
     const token = { cancelled: false };
 
     // Yield before any heavy synchronous work so the browser can paint the

--- a/src/audio/AudioManager.js
+++ b/src/audio/AudioManager.js
@@ -43,6 +43,7 @@ export class AudioManager {
    */
   start() {
     if (this.started) return;
+    // @ts-ignore — webkitAudioContext is a legacy vendor-prefixed API
     const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
     this.ctx = new AudioContextCtor();
     this.masterGain = this.ctx.createGain();

--- a/src/creatures/CreatureManager.js
+++ b/src/creatures/CreatureManager.js
@@ -40,14 +40,14 @@ let DESPAWN_DISTANCE_SQ = DESPAWN_DISTANCE * DESPAWN_DISTANCE;
 let CULL_DISTANCE_SQ = CULL_DISTANCE * CULL_DISTANCE;
 const QUEUE_DRAIN_PER_FRAME = 1;
 
-window.addEventListener('qualitychange', (e) => {
+window.addEventListener('qualitychange', (/** @type {CustomEvent} */ e) => {
   const s = e.detail.settings;
   DESPAWN_DISTANCE = s.creatureDespawnDistance;
   CULL_DISTANCE = s.creatureCullDistance;
   MAX_CREATURES = s.maxCreatures;
   DESPAWN_DISTANCE_SQ = DESPAWN_DISTANCE * DESPAWN_DISTANCE;
   CULL_DISTANCE_SQ = CULL_DISTANCE * CULL_DISTANCE;
-  CREATURE_VISIBILITY_DEPTH_BUDGETS = VISIBILITY_BUDGETS_BY_TIER[e.detail.tier] || VISIBILITY_BUDGETS_BY_TIER.high;
+  CREATURE_VISIBILITY_DEPTH_BUDGETS = VISIBILITY_BUDGETS_BY_TIER[/** @type {CustomEvent} */ (e).detail.tier] || VISIBILITY_BUDGETS_BY_TIER.high;
 });
 
 function _distSq(a, b) {

--- a/src/creatures/PipeOrgan.js
+++ b/src/creatures/PipeOrgan.js
@@ -769,6 +769,7 @@ export class PipeOrgan {
     }
 
     // Respawn when player has moved too far away
+    const dist = Math.sqrt(distSq);
     if (dist > 200) {
       const a = Math.random() * Math.PI * 2;
       this.group.position.set(

--- a/src/environment/Flora.js
+++ b/src/environment/Flora.js
@@ -187,7 +187,7 @@ export class Flora {
     // Scratch color for pool slot allocation
     this._tmpColor = new THREE.Color();
 
-    window.addEventListener("qualitychange", (e) => {
+    window.addEventListener("qualitychange", (/** @type {CustomEvent} */ e) => {
       this._floraDensityScale = e.detail.settings.floraDensityScale;
       // Mark all chunks for rebuild on next move
       if (this.lastChunkX !== null) {

--- a/src/environment/Ocean.js
+++ b/src/environment/Ocean.js
@@ -320,7 +320,7 @@ export class Ocean {
     scene.background = new THREE.Color(0x006994);
 
     // React to quality tier changes for shadow map size and castShadow
-    window.addEventListener("qualitychange", (e) => {
+    window.addEventListener("qualitychange", (/** @type {CustomEvent} */ e) => {
       const newTier = e.detail.tier;
       const size = e.detail.settings.shadowMapSize || 1024;
       this.sunLight.castShadow = newTier === "high" || newTier === "ultra";
@@ -330,7 +330,7 @@ export class Ocean {
         this.sunLight.shadow.map = null;
       }
       this._rebuildHeightfield(newTier);
-      this._rebuildParticles(e.detail.settings);
+      this._rebuildParticles(/** @type {CustomEvent} */ (e).detail.settings);
       this._rebuildWaterSurface();
     });
   }

--- a/src/environment/Terrain.js
+++ b/src/environment/Terrain.js
@@ -307,7 +307,7 @@ export class Terrain {
       this._enqueueFinalization(request.key, data.cx, data.cz, data.payload);
     };
 
-    window.addEventListener("qualitychange", (e) => {
+    window.addEventListener("qualitychange", (/** @type {CustomEvent} */ e) => {
       this.viewDistance = e.detail.settings.terrainViewDistance;
       if (this.lastChunkX !== null) {
         this._rebuildPendingAround(this.lastChunkX, this.lastChunkZ);

--- a/src/environment/chunkPayloadWorker.js
+++ b/src/environment/chunkPayloadWorker.js
@@ -473,7 +473,7 @@ if (typeof self !== "undefined") {
         cx: data.cx,
         cz: data.cz,
         payload,
-      }, collectTerrainTransferList(payload));
+      }, /** @type {*} */ (collectTerrainTransferList(payload)));
       return;
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ const game = new Game(await Game.resolveRendererOptions());
 await game.init();
 
 // Expose game instance globally for automated testing (UX Tester / Chrome DevTools)
+// @ts-ignore — custom global for test automation
 window.game = game;
 
 document.getElementById('loading').classList.add('hidden');

--- a/src/physics/PhysicsWorld.js
+++ b/src/physics/PhysicsWorld.js
@@ -9,6 +9,7 @@ export class PhysicsWorld {
   }
 
   async init() {
+    // @ts-ignore — Rapier WASM init accepts optional config
     await RAPIER.init({});
     // Zero gravity — the game handles movement via velocity + drag
     this.world = new RAPIER.World({ x: 0, y: 0, z: 0 });

--- a/src/player/Player.js
+++ b/src/player/Player.js
@@ -135,7 +135,7 @@ export class Player {
 
     document.addEventListener("pointerlockchange", () => {
       this.locked = document.pointerLockElement === this.domElement;
-      if (this.onLockChange) this.onLockChange(this.locked);
+      if (/** @type {any} */ (this).onLockChange) /** @type {any} */ (this).onLockChange(this.locked);
     });
   }
 

--- a/src/shaders/UnderwaterEffect.js
+++ b/src/shaders/UnderwaterEffect.js
@@ -637,7 +637,7 @@ export class UnderwaterEffect {
     this._rebuildScaleLadder();
     this._applyComposerScale(true);
 
-    window.addEventListener("qualitychange", (e) => {
+    window.addEventListener("qualitychange", (/** @type {CustomEvent} */ e) => {
       this._qualityMaxScale = e.detail.settings.postProcessScale;
       this._setupBloom(e.detail.tier);
       this._setupGodrays(e.detail.tier);

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -38,7 +38,7 @@ export class HUD {
     this.depthDisplay = document.getElementById('depth-display');
     this.depthZone = document.getElementById('depth-zone');
     this.warningText = document.getElementById('warning-text');
-    this.sonarCanvas = document.getElementById('sonar');
+    this.sonarCanvas = /** @type {HTMLCanvasElement} */ (document.getElementById('sonar'));
     this.sonarCtx = this.sonarCanvas.getContext('2d');
     this.warningTimer = 0;
     this.sonarPings = [];
@@ -72,7 +72,7 @@ export class HUD {
     this._bgLoadingVisible = false;
 
     this.creatureList.addEventListener('click', (e) => {
-      const entry = e.target.closest('.creature-entry');
+      const entry = /** @type {HTMLElement|null} */ (/** @type {Element} */ (e.target).closest('.creature-entry'));
       if (!entry || !entry.dataset.creatureType) return;
       this.selectedCreatureType = entry.dataset.creatureType;
       this.selectedCreatureIndex = this.creatureTypes.indexOf(this.selectedCreatureType);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": false,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["node_modules", "dist", "scripts"]
+}


### PR DESCRIPTION
## Summary

Configures TypeScript to type-check existing JavaScript files via JSDoc annotations, without migrating any source files to `.ts`.

### Changes

**New files:**
- `tsconfig.json` — `allowJs`, `checkJs`, `noEmit`, `strict: false`, `module: "ESNext"`, `moduleResolution: "bundler"`, `skipLibCheck: true`. Includes `src/**/*.js`, excludes `node_modules`, `dist`, `scripts`.

**package.json:**
- Added `"typecheck": "npx tsc --noEmit"` script

**Bug fix (PipeOrgan.js):**
- Fixed undefined `dist` variable in respawn check — was referencing nonexistent `dist` when only `distSq` (distance squared) was available as a parameter. Added `const dist = Math.sqrt(distSq)` before the check.

**Type annotation fixes (14 files):**
- Added JSDoc `@type {CustomEvent}` casts on all `qualitychange` event listeners (CreatureManager, Flora, Ocean, Terrain, Game, UnderwaterEffect)
- Added JSDoc DOM type narrowing in HUD.js (`HTMLCanvasElement` for sonar canvas, `HTMLElement` for closest)
- Added `@ts-ignore` for vendor-specific APIs (`webkitAudioContext`, Rapier WASM init)
- Added JSDoc `any` casts for dynamic Three.js WebGPU properties (`forceWebGL`, `featureLevel`), dynamic callbacks (`onLockChange`), and destructuring defaults (`onProgress`)
- Added JSDoc cast for worker `postMessage` transfer list overload

### Validation

- `npm run typecheck` exits 0 (zero errors)
- `npm run build` passes

Fixes #337