### PR TITLE
ci: add quality gate workflow for PRs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,20 @@
+name: Quality Gate
+
+on:
+    pull_request:
+        branches: [main]
+
+jobs:
+    quality:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+            - run: npm ci
+            - run: npm run lint
+            - run: npm run typecheck
+            - run: npm run test
+            - run: npm run build

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     quality:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Add a GitHub Actions workflow (`.github/workflows/quality.yml`) that runs on every PR targeting `main` and blocks merges on lint, type-check, test, or build failures.

**Steps run in order (fail-fast, cheapest first):**
1. `npm ci` — reproducible install
2. `npm run lint`
3. `npm run typecheck`
4. `npm run test`
5. `npm run build`

Uses Node 20 and `actions/checkout@v4` / `actions/setup-node@v4`, consistent with the existing deploy-pages workflow.

Fixes #342